### PR TITLE
Support for Moodle custom profile field mapping

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -264,7 +264,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
                     $updateonlogin = $mapconfig->{'field_updatelocal_'.$field} === 'onlogin';
 
                     if ($newuser || $updateonlogin) {
-                        //Determine which fields are custom profile fields and act accordingly
+                        // Determine which fields are custom profile fields and act accordingly.
                         if (in_array($field, $customFields)) {
                                 $user->{'profile_field_'.$field} = $attributes[$attr][0];
                                 //TODO WARNING data validation should be done before saving custom fields back currently if the SAML data is not of the correct type an error is displayed to the user and they cannot log in!

--- a/auth.php
+++ b/auth.php
@@ -169,7 +169,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
         // preserved forcing us to the IdP.
         //
         // This isn't needed when duallogin is on because $saml will default to 0
-        // and duallogin is not part of the request
+        // and duallogin is not part of the request.
         if ((isset($SESSION->saml) && $SESSION->saml == 0)) {
             $this->log(__FUNCTION__ . ' skipping due to no sso session');
             return;
@@ -245,10 +245,10 @@ class auth_plugin_saml2 extends auth_plugin_base {
 
         // Grab custom profile fields list for use later on
         // TODO Probably a better way to do this?
-        $customProfileFieldsData = $DB->get_records('user_info_field');
-        $customFields = array();
-        foreach($customProfileFieldsData as $field){
-                $customFields[] = $field->shortname;
+        $customprofilefieldsdata = $DB->get_records('user_info_field');
+        $customfields = array();
+        foreach($customprofilefieldsdata as $field) {
+                $customfields[] = $field->shortname;
         }
 
         // Do we need to update any user fields? Unlike ldap, we can only do
@@ -267,7 +267,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
                         // Determine which fields are custom profile fields and act accordingly.
                         if (in_array($field, $customFields)) {
                                 $user->{'profile_field_'.$field} = $attributes[$attr][0];
-                                //TODO WARNING data validation should be done before saving custom fields back currently if the SAML data is not of the correct type an error is displayed to the user and they cannot log in!
+                                // TODO WARNING data validation should be done before saving custom fields back currently if the SAML data is not of the correct type an error is displayed.
                         } else {
                                 $user->$field = $attributes[$attr][0];
                         }
@@ -280,7 +280,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
         if ($touched) {
             require_once($CFG->dirroot . '/user/lib.php');
             user_update_user($user, false, false);
-            //Save custom profile fields
+            // Save custom profile fields.
             profile_save_data($user);
         }
 
@@ -319,7 +319,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
         //
         // 1) The moodle session
         // 2) The SimpleSAML SP session
-        // 3) The IdP session, if the IdP supports SingleSignout
+        // 3) The IdP session, if the IdP supports SingleSignout.
 
         global $CFG, $saml2auth, $redirect;
 

--- a/auth.php
+++ b/auth.php
@@ -364,7 +364,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
     public function config_form($config, $err, $userfields) {
         $config = (object) array_merge($this->defaults, (array) $config );
         global $CFG, $OUTPUT;
-        include("settings.html");
+        include($CFG->dirroot.'/auth/saml2/settings.html');
     }
 
     /**

--- a/auth.php
+++ b/auth.php
@@ -247,7 +247,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
         // TODO Probably a better way to do this?
         $customprofilefieldsdata = $DB->get_records('user_info_field');
         $customfields = array();
-        foreach($customprofilefieldsdata as $field) {
+        foreach ($customprofilefieldsdata as $field) {
                 $customfields[] = $field->shortname;
         }
 
@@ -265,9 +265,9 @@ class auth_plugin_saml2 extends auth_plugin_base {
 
                     if ($newuser || $updateonlogin) {
                         // Determine which fields are custom profile fields and act accordingly.
-                        if (in_array($field, $customFields)) {
+                        if (in_array($field, $customfields)) {
                                 $user->{'profile_field_'.$field} = $attributes[$attr][0];
-                                // TODO WARNING data validation should be done before saving custom fields back currently if the SAML data is not of the correct type an error is displayed.
+                                // TODO data validation should be done before saving custom fields back currently if the SAML data is not of the correct type an error is displayed.
                         } else {
                                 $user->$field = $attributes[$attr][0];
                         }

--- a/settings.html
+++ b/settings.html
@@ -120,14 +120,6 @@ $fields = array(
 </tr>
 
 <?php
-        //Grab custom profile fields from Moodle and put into an array that we can pass to print_auth_lock_options()
-        global $DB;
-        $customProfileFieldsData = $DB->get_records('user_info_field');
-        $customFields = array();
-        foreach($customProfileFieldsData as $field){
-                $customFields[] = $field->shortname;
-        }
-
-        print_auth_lock_options('saml2', $userfields, '<!-- empty help -->', true, false, $customFields);
+        print_auth_lock_options('saml2', $userfields, '<!-- empty help -->', true, false, $this->get_custom_user_profile_fields());
 </table>
 

--- a/settings.html
+++ b/settings.html
@@ -119,6 +119,15 @@ $fields = array(
         <?php print_string($field.'_help', 'auth_saml2') ?></td>
 </tr>
 
-<?php print_auth_lock_options('saml2', $userfields, '<!-- empty help -->', true, false); ?>
+<?php
+        //Grab custom profile fields from Moodle and put into an array that we can pass to print_auth_lock_options()
+        global $DB;
+        $customProfileFieldsData = $DB->get_records('user_info_field');
+        $customFields = array();
+        foreach($customProfileFieldsData as $field){
+                $customFields[] = $field->shortname;
+        }
+
+        print_auth_lock_options('saml2', $userfields, '<!-- empty help -->', true, false, $customFields);
 </table>
 


### PR DESCRIPTION
I have added code to enable mapping of custom moodle profile fields.

Could do with a point in the right direction in terms of custom profile field validation because of the following. Currently the custom fields are saved back without validation therefore if the data is not correct an error is displayed to the user and they cannot log in. eg custom field is a drop down with accepted values 1,2,3,4 if the request gets value 5 an error is given.

This is the first time I have used GitHub, and my first time coding for Moodle so a few things may be bad practice. This is also a copy and paste from my code rather than a pull into my repo so apologies if I have forgotten to copy something over.