### PR TITLE
Issue #13 mcrypt warning during upgrade/install on environment page.

### DIFF
--- a/environment.xml
+++ b/environment.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<COMPATIBILITY_MATRIX>
+  <PLUGIN name="auth_saml2">
+    <PHP_EXTENSIONS>
+      <!-- Extension prerequisites for SimpleSAMLphp https://simplesamlphp.org/docs/stable/simplesamlphp-install#section_3 -->
+      <PHP_EXTENSION name="date" level="required" />
+      <PHP_EXTENSION name="dom" level="required" />
+      <PHP_EXTENSION name="hash" level="required" />
+      <PHP_EXTENSION name="libxml" level="required" />
+      <PHP_EXTENSION name="mcrypt" level="required" />
+      <PHP_EXTENSION name="openssl" level="required" />
+      <PHP_EXTENSION name="pcre" level="required" />
+      <PHP_EXTENSION name="spl" level="required" />
+      <PHP_EXTENSION name="zlib" level="required" />
+    </PHP_EXTENSIONS>
+  </PLUGIN>
+</COMPATIBILITY_MATRIX>


### PR DESCRIPTION
If auth_saml2's code has been checked out, during an install or upgrade Moodle will check this environment.xml for extension dependencies.