### PR TITLE
Correct logout link for this Moodle installation

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -150,11 +150,13 @@ class auth_plugin_saml2 extends auth_plugin_base {
     public function error_page($msg) {
         global $PAGE, $OUTPUT, $SITE;
 
+        $logouturl = new moodle_url('/auth/saml2/logout.php');
+
         $PAGE->set_course($SITE);
         $PAGE->set_url('/');
         echo $OUTPUT->header();
         echo $OUTPUT->box($msg);
-        echo html_writer::link('/auth/saml2/logout.php', get_string('logout'));
+        echo html_writer::link($logouturl, get_string('logout'));
         echo $OUTPUT->footer();
         exit;
     }


### PR DESCRIPTION
If an SAML assertion is received but it cannot be matched against a Moodle user, an error is displayed with a Logout link.

![auth_saml2 error](https://cloud.githubusercontent.com/assets/1216362/20603049/97ef34b6-b257-11e6-8845-cf9fbd02f56d.png)

This link is relative to the server root, not to the root of the Moodle installation. This is not a problem if Moodle is installed directly into the server root, but does not work if it is installed in a subdirectory.

For example, if Moodle is installed at:

https://www.example.com/subdomain/

then the link should be:

https://www.example.com/subdomain/auth/saml2/logout.php

but it will actually point to:

https://www.example.com/auth/saml2/logout.php