### PR TITLE
Added support for moodle loginhttps configuration

### DIFF
--- a/config/authsources.php
+++ b/config/authsources.php
@@ -24,10 +24,16 @@
 
 global $saml2auth, $CFG, $SITE;
 
+// Check for https login
+$wwwroot = $CFG->wwwroot;
+if (!empty($CFG->loginhttps)) {
+    $wwwroot = str_replace('http:','https:',$CFG->wwwroot);
+}
+
 $config = array(
     $saml2auth->spname => array(
         'saml:SP',
-        'entityID' => "$CFG->wwwroot/auth/saml2/sp/metadata.php",
+        'entityID' => "$wwwroot/auth/saml2/sp/metadata.php",
         'idp' => $saml2auth->config->entityid,
         'NameIDPolicy' => null,
         'OrganizationName' => array(
@@ -47,4 +53,3 @@ $config = array(
         'signature.algorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
     ),
 );
-

--- a/config/authsources.php
+++ b/config/authsources.php
@@ -24,10 +24,10 @@
 
 global $saml2auth, $CFG, $SITE;
 
-// Check for https login
+// Check for https login.
 $wwwroot = $CFG->wwwroot;
 if (!empty($CFG->loginhttps)) {
-    $wwwroot = str_replace('http:','https:',$CFG->wwwroot);
+    $wwwroot = str_replace('http:', 'https:', $CFG->wwwroot);
 }
 
 $config = array(

--- a/config/config.php
+++ b/config/config.php
@@ -24,8 +24,14 @@
 
 global $CFG, $saml2auth;
 
+// Check for https login
+$wwwroot = $CFG->wwwroot;
+if (!empty($CFG->loginhttps)) {
+    $wwwroot = str_replace('http:','https:',$CFG->wwwroot);
+}
+
 $config = array(
-    'baseurlpath'       => $CFG->wwwroot . '/auth/saml2/sp/',
+    'baseurlpath'       => $wwwroot . '/auth/saml2/sp/',
     'certdir'           => $saml2auth->certdir,
     'debug'             => $saml2auth->config->debug ? true : false,
     'logging.level'     => $saml2auth->config->debug ? SimpleSAML_Logger::DEBUG : SimpleSAML_Logger::ERR,

--- a/config/config.php
+++ b/config/config.php
@@ -24,10 +24,10 @@
 
 global $CFG, $saml2auth;
 
-// Check for https login
+// Check for https login.
 $wwwroot = $CFG->wwwroot;
 if (!empty($CFG->loginhttps)) {
-    $wwwroot = str_replace('http:','https:',$CFG->wwwroot);
+    $wwwroot = str_replace('http:', 'https:', $CFG->wwwroot);
 }
 
 $config = array(

--- a/extlib/simplesamlphp/modules/saml/lib/Auth/Source/SP.php
+++ b/extlib/simplesamlphp/modules/saml/lib/Auth/Source/SP.php
@@ -171,8 +171,6 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 	 * @param array $state  The state array for the current authentication.
 	 */
 	private function startSSO2(SimpleSAML_Configuration $idpMetadata, array $state) {
-		// auth_saml2 modification:
-		global $CFG, $saml2auth;
 
 		if (isset($state['saml:ProxyCount']) && $state['saml:ProxyCount'] < 0) {
 			SimpleSAML_Auth_State::throwException($state, new SimpleSAML_Error_ProxyCountExceeded("ProxyCountExceeded"));
@@ -180,9 +178,10 @@ class sspmod_saml_Auth_Source_SP extends SimpleSAML_Auth_Source {
 
 		$ar = sspmod_saml_Message::buildAuthnRequest($this->metadata, $idpMetadata);
 
-		//$ar->setAssertionConsumerServiceURL(SimpleSAML_Module::getModuleURL('saml/sp/saml2-acs.php/' . $this->authId));
-		// auth_saml2 modification:
-		$ar->setAssertionConsumerServiceURL($CFG->wwwroot . '/auth/saml2/sp/saml2-acs.php/' . $saml2auth->spname);
+		// auth_saml2 modification
+		$baseurl = SimpleSAML_Module::getModuleURL('saml/sp/saml2-acs.php/' . $this->authId);
+		$baseurl = str_replace('module.php/saml/sp/', '', $baseurl);
+		$ar->setAssertionConsumerServiceURL($baseurl);
 
 		if (isset($state['SimpleSAML_Auth_Source.ReturnURL'])) {
 			$ar->setRelayState($state['SimpleSAML_Auth_Source.ReturnURL']);


### PR DESCRIPTION
In Moodle, one is able to force the login process to use HTTPS. The plugin was not implementing that configuration value, and the assertion consumer service URL was always using $CFG->wwwroot. I removed the global variable insertions for better compatibility with the rest of SimpleSAMLphp, and added a check to force HTTPS.

This has been tested on my connected systems and works appropriately.

Thanks for the great plugin!