### PR TITLE
Better handle certificate generation errors

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -76,20 +76,22 @@ function create_certificates($saml2auth, $dn = false, $numberofdays = 3650) {
         );
     }
 
+    certificate_openssl_error_strings(); // Ensure existing messages are dropped
     $privkeypass = get_site_identifier();
     $privkey = openssl_pkey_new();
     $csr     = openssl_csr_new($dn, $privkey);
     $sscert  = openssl_csr_sign($csr, null, $privkey, $numberofdays);
     openssl_x509_export($sscert, $publickey);
     openssl_pkey_export($privkey, $privatekey, $privkeypass);
+    $errors = certificate_openssl_error_strings();
 
     // Write Private Key and Certificate files to disk.
     // If there was a generation error with either explode.
     if (empty($privatekey)) {
-        return get_string('nullprivatecert', 'auth_saml2');
+        return get_string('nullprivatecert', 'auth_saml2') . $errors;
     }
     if (empty($publickey)) {
-        return get_string('nullpubliccert', 'auth_saml2');
+        return get_string('nullpubliccert', 'auth_saml2') . $errors;
     }
 
     if ( !file_put_contents($saml2auth->certpem, $privatekey) ) {
@@ -99,6 +101,20 @@ function create_certificates($saml2auth, $dn = false, $numberofdays = 3650) {
         return get_string('nullpubliccert', 'auth_saml2');
     }
 
+}
+
+/**
+ * Collect and render a list of OpenSSL error messages.
+ *
+ * @return string
+ */
+function certificate_openssl_error_strings() {
+    $errors = array();
+    while ($error = openssl_error_string()) {
+        $errors[] = $error;
+    }
+
+    return html_writer::alist($errors);
 }
 
 /**


### PR DESCRIPTION
Under Windows installations in particular, it's not unusual to find that the OpenSSL configuration file (`openssl.cnf`) to be either missing or invalid. On our testing environment, this resulted in the "Regenerate certificate" process failing with no meaningful error output.

This patch fetches the OpenSSL errors and outputs them in a list. The output is along the lines of the following in the case of a missing configuration file:
```
error:02001003:system library:fopen:No such process
error:2006D080:BIO routines:BIO_new_file:no such file
error:0E064002:configuration file routines:CONF_load:system lib
error:02001003:system library:fopen:No such process
error:2006D080:BIO routines:BIO_new_file:no such file
error:0E064002:configuration file routines:CONF_load:system lib
error:02001003:system library:fopen:No such process
error:2006D080:BIO routines:BIO_new_file:no such file
error:0E064002:configuration file routines:CONF_load:system lib
error:02001003:system library:fopen:No such process
error:2006D080:BIO routines:BIO_new_file:no such file
error:0E064002:configuration file routines:CONF_load:system lib
```