### PR TITLE
Handle OPENSSL_CONF env var if defined

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -61,6 +61,11 @@ SimpleSAML_Configuration::setConfigDir("$CFG->dirroot/auth/saml2/config");
 function create_certificates($saml2auth, $dn = false, $numberofdays = 3650) {
     global $CFG, $SITE;
 
+    $opensslargs = array();
+    if (array_key_exists('OPENSSL_CONF', $_SERVER)) {
+        $opensslargs['config'] = $_SERVER['OPENSSL_CONF'];
+    }
+
     if ($dn == false) {
         // These are somewhat arbitrary and aren't really seen except inside
         // the auto created certificate used to sign saml requests.
@@ -77,11 +82,11 @@ function create_certificates($saml2auth, $dn = false, $numberofdays = 3650) {
     }
 
     $privkeypass = get_site_identifier();
-    $privkey = openssl_pkey_new();
-    $csr     = openssl_csr_new($dn, $privkey);
-    $sscert  = openssl_csr_sign($csr, null, $privkey, $numberofdays);
+    $privkey = openssl_pkey_new($opensslargs);
+    $csr     = openssl_csr_new($dn, $privkey, $opensslargs);
+    $sscert  = openssl_csr_sign($csr, null, $privkey, $numberofdays, $opensslargs);
     openssl_x509_export($sscert, $publickey);
-    openssl_pkey_export($privkey, $privatekey, $privkeypass);
+    openssl_pkey_export($privkey, $privatekey, $privkeypass, $opensslargs);
 
     // Write Private Key and Certificate files to disk.
     // If there was a generation error with either explode.


### PR DESCRIPTION
The OpenSSL extension doesn't always correctly handle the `OPENSSL_CONF` environment variable. We should be explicit about which configuration file we'd like to use if the user has declared it within their environment.