### PR TITLE
Document OPENSSL_CONF env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,22 @@ $ chmod 0660 site.example.crt
 $ chmod 0660 site.example.pem
 ```
 
+**OpenSSL errors during certificate regeneration**
+
+Some environments, particularly Windows-based, may not provide an OpenSSL
+configuration file at the default location, producing errors like the
+following when regenerating certificates:
+
+```
+error:02001003:system library:fopen:No such process
+error:2006D080:BIO routines:BIO_new_file:no such file
+error:0E064002:configuration file routines:CONF_load:system lib
+```
+
+To work around this, set the `OPENSSL_CONF` environment variable to the location
+of [`openssl.cnf`](https://www.openssl.org/docs/manmaster/man5/config.html)
+within your environment.
+
 
 Other SAML plugins
 ------------------


### PR DESCRIPTION
Provides documentation for the `OPENSSL_CONF` environment variable as suggested in #83.

I've placed it under the gotchas section of the README because it shouldn't be relevant to users of standard configurations, but am happy to relocate it. I've linked to the relevant OpenSSL documentation too.

Thanks for the prompt responses to PRs, much appreciated!