### PR TITLE
Fix path handling on Windows

### DIFF
--- a/extlib/simplesamlphp/lib/SimpleSAML/Utils/System.php
+++ b/extlib/simplesamlphp/lib/SimpleSAML/Utils/System.php
@@ -114,6 +114,10 @@ class System
             $base = $config->getBaseDir();
         }
 
+        // normalise directory separator
+        $base = str_replace(DIRECTORY_SEPARATOR, '/', $base);
+        $path = str_replace(DIRECTORY_SEPARATOR, '/', $path);
+
         // remove trailing slashes
         $base = rtrim($base, '/');
 
@@ -121,6 +125,8 @@ class System
         if (substr($path, 0, 1) === '/') {
             // absolute path. */
             $ret = '/';
+        } elseif (static::getOS() === static::WINDOWS && static::pathContainsDriveLetter($path)) {
+            $ret = '';
         } else {
             // path relative to base
             $ret = $base;
@@ -133,7 +139,7 @@ class System
             } elseif ($d === '..') {
                 $ret = dirname($ret);
             } else {
-                if (substr($ret, -1) !== '/') {
+                if ($ret && substr($ret, -1) !== '/') {
                     $ret .= '/';
                 }
                 $ret .= $d;
@@ -193,5 +199,19 @@ class System
             throw new \SimpleSAML_Error_Exception('Error moving "'.$tmpFile.'" to "'.
                 $filename.'": '.$error['message']);
         }
+    }
+
+    /**
+     * Check if the supplied path contains a Windows-style drive letter.
+     *
+     * @param string $path
+     *
+     * @return bool
+     */
+    private static function pathContainsDriveLetter($path)
+    {
+        $letterAsciiValue = ord(strtoupper(substr($path, 0, 1)));
+        return substr($path, 1, 1) === ':'
+                && $letterAsciiValue >= 65 && $letterAsciiValue <= 90;
     }
 }


### PR DESCRIPTION
Under Windows, it appears as though paths containing drive letters aren't handled correctly in `SimpleSAML_Configuration::resolvePath()`. They should be treated as absolute, but SimpleSAMLphp only treats paths starting with `/` this way.

I realise I've patched SimpleSAMLphp to achieve this and I can see that there are some Moodle-specific patches in SimpleSAMLphp but couldn't find any documentation on these. I suspect this patch really belongs upstream, but I would appreciate it if we could include a workaround in the plugin's fork for the time being?

Thanks in advance.