### PR TITLE
Add hook for custom parameters

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -279,8 +279,15 @@ class auth_plugin_saml2 extends auth_plugin_base {
 
         require_once('setup.php');
         require_once("$CFG->dirroot/login/lib.php");
+
+        if (!empty($CFG->auth_saml2_params)) {
+            $params = call_user_func($CFG->auth_saml2_params);
+        } else {
+            $params = array();
+        }
+
         $auth = new SimpleSAML_Auth_Simple($this->spname);
-        $auth->requireAuth();
+        $auth->requireAuth($params);
         $attributes = $auth->getAttributes();
 
         $attr = $this->config->idpattr;


### PR DESCRIPTION
I'm not convinced this is the tidiest way to accomplish the intended result, so feedback is most definitely welcome. If some form of middleware implementation is planned for this plugin, this might be an interesting requirement to accommodate through some other means.

TL;DR: adds a hook to `\auth_plugin_saml2::saml_login()` which allows you to specify custom `$params` to `\SimpleSAML_Auth_Simple::requireAuth()`.

The B2B portion of our business had a requirement for a SAML2 configuration between multiple SPs (all Moodle at present, though this may change in the future) and multiple IdPs. In order to achieve this, we configured a standalone SimpleSAMLphp instance to behave as an identity broker, behaving an SP to external IdPs and providing an internal IdP using its own SAML SP as an authentication source.

In this configuration, following links to the identity broker to authenticate will prompt SimpleSAMLphp to display a list of available identity providers, allowing the user to select the one they wish to authenticate with.

In order to facilitate white labeling a Moodle instance, we configure multiple domains for the same Moodle installation and provide different theme configurations based on the domain. This patch enables us to also customise the SAML2 plugin's configuration, appending different [scoping options](https://simplesamlphp.org/docs/stable/simplesamlphp-scoping) to the `AuthnRequest`, e.g.:

```php
$CFG->auth_saml2_params = function() {
    return array(
        'saml:IDPList' => array(
            'http://example.com/saml2/idp/metadata.php'
        ),
        'saml:ProxyCount' => 2,
    );
};
```