### PR TITLE
#101 Prevent access to users who are either suspended or deleted

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -279,15 +279,15 @@ class auth_plugin_saml2 extends auth_plugin_base {
                 $this->log(__FUNCTION__ . " to lowercase for $key => $uid");
                 $uid = strtolower($uid);
             }
-            if ($user = $DB->get_record('user', array( $this->config->mdlattr => $uid ))) {
+            if ($user = $DB->get_record('user', array( $this->config->mdlattr => $uid, 'deleted' => 0 ))) {
                 continue;
             }
         }
 
-        // Prevent access to users who are either suspended or deleted
-        if ($user->suspended || $user->deleted) {
-            $this->error_page(get_string('nouser', 'auth_saml2', $uid));
-        }        
+        // Prevent access to users who are suspended
+        if ($user->suspended) {
+            $this->error_page(get_string('suspendeduser', 'auth_saml2', $uid));
+        }
 
         $newuser = false;
         if (!$user) {

--- a/auth.php
+++ b/auth.php
@@ -284,6 +284,11 @@ class auth_plugin_saml2 extends auth_plugin_base {
             }
         }
 
+        // Prevent access to users who are either suspended or deleted
+        if ($user->suspended || $user->deleted) {
+            $this->error_page(get_string('nouser', 'auth_saml2', $uid));
+        }        
+
         $newuser = false;
         if (!$user) {
             if ($this->config->autocreate) {

--- a/lang/en/auth_saml2.php
+++ b/lang/en/auth_saml2.php
@@ -53,6 +53,7 @@ $string['anyauth'] = 'Allowed any auth type';
 $string['anyauth_help'] = 'Yes: Allow SAML login for all users? No: Only users who have saml2 as their type.';
 $string['wrongauth'] = 'You have logged in succesfully as \'{$a}\' but are not authorized to access Moodle.';
 $string['nouser'] = 'You have logged in succesfully as \'{$a}\' but do not have an account in Moodle.';
+$string['suspendeduser'] = 'You have logged in succesfully as \'{$a}\' but your account has been suspended in Moodle.';
 $string['noattribute'] = 'You have logged in succesfully but we could not find your \'{$a}\' attribute to associate you to an account in Moodle.';
 $string['tolower'] = 'Lowercase';
 $string['tolower_help'] = 'Apply lowercase to IdP attribute before matching?';


### PR DESCRIPTION
This is to fix bug #101 which currently allows users to login to Moodle even if their account is either suspended or deleted (though a user with a deleted account will encounter a PHP exception).