### PR TITLE
Moving the SSL Proxy port overide up a level to the setup.php 

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -26,6 +26,11 @@ require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
 require_once(dirname(__FILE__).'/_autoload.php');
 require_once("$CFG->dirroot/auth/saml2/auth.php");
 
+// Tell SSP that we are on 443 if we are terminating SSL elsewhere.
+if (isset($CFG->sslproxy) && $CFG->sslproxy) {
+      $_SERVER['SERVER_PORT'] = '443';
+}
+
 $saml2auth = new auth_plugin_saml2();
 
 // Auto create unique certificates for this moodle SP.

--- a/sp/saml1-acs.php
+++ b/sp/saml1-acs.php
@@ -27,10 +27,5 @@ require_once('../setup.php');
 // First setup the PATH_INFO because that's how SSP rolls.
 $_SERVER['PATH_INFO'] = '/' . $saml2auth->spname;
 
-// Tell SSP that we are on 443 if we are terminating SSL elsewhere.
-if (isset($CFG->sslproxy) && $CFG->sslproxy) {
-    $_SERVER['SERVER_PORT'] = '443';
-}
-
 require($CFG->dirroot.'/auth/saml2/extlib/simplesamlphp/modules/saml/www/sp/saml1-acs.php');
 

--- a/sp/saml2-acs.php
+++ b/sp/saml2-acs.php
@@ -27,10 +27,5 @@ require_once('../setup.php');
 // First setup the PATH_INFO because that's how SSP rolls.
 $_SERVER['PATH_INFO'] = '/' . $saml2auth->spname;
 
-// Tell SSP that we are on 443 if we are terminating SSL elsewhere.
-if (isset($CFG->sslproxy) && $CFG->sslproxy) {
-    $_SERVER['SERVER_PORT'] = '443';
-}
-
 require($CFG->dirroot.'/auth/saml2/extlib/simplesamlphp/modules/saml/www/sp/saml2-acs.php');
 


### PR DESCRIPTION
This should make the SSL Port get correctly set when moodle is used in reverse proxy mode.