### PR TITLE
Issue #140: Allow saml2 auth method to be manually set for users

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -554,5 +554,13 @@ class auth_plugin_saml2 extends auth_plugin_base {
         return $config->getVersion();
     }
 
+    /**
+     * Allow saml2 auth method to be manually set for users e.g. bulk uploading users.
+     */
+
+    public function can_be_manually_set() {
+        return true;
+    }
+
 }
 


### PR DESCRIPTION
Add override in auth/saml2/auth.php code to the can_be_manually_set() function (set to true) to allow the saml2 auth method to be set for users, e.g. when bulk uploading users.