### PR TITLE
Added support for using Redis as the store

### DIFF
--- a/classes/redis_store.php
+++ b/classes/redis_store.php
@@ -1,0 +1,149 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Redis store simpleSAMLphp class for auth/saml2.
+ *
+ * @package    auth_saml2
+ * @author     Sam Chaffee
+ * @copyright  Copyright (c) 2017 Blackboard Inc. (http://www.blackboard.com)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace auth_saml2;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . '/../extlib/simplesamlphp/lib/SimpleSAML/Store.php');
+
+/**
+ * Redis store simpleSAMLphp class for auth/saml2.
+ *
+ * @package    auth_saml2
+ * @copyright  Copyright (c) 2017 Blackboard Inc. (http://www.blackboard.com)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class redis_store extends \SimpleSAML_Store {
+
+    /**
+     * @var \Redis
+     */
+    protected $redis;
+
+    /**
+     * @var string
+     */
+    protected $prefix;
+
+    public function __construct($redis = null) {
+        global $CFG;
+
+        $this->prefix = 'simpleSAMLphp.' . $CFG->dbname . '.';
+
+        if (!$redis instanceof \Redis) {
+            $redis = $this->bootstrap_redis();
+        }
+        $this->redis = $redis;
+    }
+
+    /**
+     * @param string   $type
+     * @param string   $key
+     * @param mixed    $value
+     * @param int|null $expire
+     */
+    public function set($type, $key, $value, $expire = null) {
+        $this->redis->set($this->make_key($type, $key), $value, $this->get_set_options($expire));
+    }
+
+    /**
+     * @param string $type
+     * @param string $key
+     * @return mixed|null
+     */
+    public function get($type, $key) {
+        $value = $this->redis->get($this->make_key($type, $key));
+        if ($value === false) {
+            $value = null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param string $type
+     * @param string $key
+     */
+    public function delete($type, $key) {
+        $this->redis->del($this->make_key($type, $key));
+    }
+
+    /**
+     * Bootstraps a \Redis instance.
+     *
+     * @return \Redis
+     * @throws \coding_exception
+     */
+    protected function bootstrap_redis() {
+        global $CFG;
+
+        if (!class_exists('Redis')) {
+            throw new \coding_exception('Redis class not found, Redis PHP Extension is probably not installed');
+        }
+        if (empty($CFG->auth_saml2_redis_server)) {
+            throw new \coding_exception('Redis connection string is not configured in $CFG->auth_saml2_redis_server');
+        }
+
+        try {
+            $redis = new \Redis();
+            $redis->connect($CFG->auth_saml2_redis_server);
+        } catch (\RedisException $e) {
+            throw new \coding_exception("RedisException caught with message: {$e->getMessage()}");
+        }
+
+        if (!$redis->setOption(\Redis::OPT_PREFIX, $this->prefix)) {
+            throw new \coding_exception('Could not set Redis prefix option: ' . $this->prefix);
+        }
+        if (!$redis->setOption(\Redis::OPT_SERIALIZER, \Redis::SERIALIZER_PHP)) {
+            throw new \coding_exception('Could not set Redis serializer option to PHP Serializer');
+        }
+        return $redis;
+    }
+
+    /**
+     * @param string $type
+     * @param string $key
+     * @return string
+     */
+    protected function make_key($type, $key) {
+        return $type . '.' . $key;
+    }
+
+    /**
+     * @param null|int $expire
+     * @return array
+     */
+    protected function get_set_options($expire) {
+        $options = [];
+
+        $now = time();
+        if ($expire !== null && $expire > $now) {
+            $options['ex'] = $expire - $now;
+        }
+
+        return $options;
+    }
+}

--- a/config/config.php
+++ b/config/config.php
@@ -71,7 +71,7 @@ $config = array(
         array('type' => 'xml', 'file' => "$CFG->dataroot/saml2/idp.xml"),
     ),
 
-    'store.type' => '\\auth_saml2\\store',
+    'store.type' => !empty($CFG->auth_saml2_store) ? $CFG->auth_saml2_store : '\\auth_saml2\\store',
 
     'proxy' => null, // TODO inherit from moodle conf see http://moodle.local/admin/settings.php?section=http for more.
 

--- a/tests/redis_store_test.php
+++ b/tests/redis_store_test.php
@@ -1,0 +1,133 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Testcase class for auth/saml2 Redis store.
+ *
+ * @package    auth_saml2
+ * @author     Sam Chaffee
+ * @copyright  Copyright (c) 2017 Blackboard Inc. (http://www.blackboard.com)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+use auth_saml2\redis_store;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Testcase class for auth/saml2 Redis store.
+ *
+ * @package    auth_saml2
+ * @copyright  Copyright (c) 2017 Blackboard Inc. (http://www.blackboard.com)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class auth_saml2_redis_store_testcase extends advanced_testcase {
+
+    /**
+     * @var null|\Redis
+     */
+    protected $redis;
+
+    public function setUp() {
+        if (!$this->is_redis_available()) {
+            $this->markTestSkipped('Redis was not available - skipping test');
+        }
+
+        $this->redis = new \Redis();
+        $this->redis->connect(AUTH_SAML2_REDIS_STORE_TEST_SERVER);
+        $this->redis->setOption(\Redis::OPT_PREFIX, 'simpleSAMLphp.testdbname.');
+        $this->redis->setOption(\Redis::OPT_SERIALIZER, \Redis::SERIALIZER_PHP);
+    }
+
+    public function tearDown() {
+        unset($this->redis);
+    }
+
+    public function test_set_with_expire() {
+        $now = time();
+        $expectedttl = 60;
+        $expire = $now + $expectedttl;
+        $redisstore = new redis_store($this->redis);
+        $redisstore->set('session', '12345&$%8', (object) ['k' => 'v', 'k2' => 'v2'], $expire);
+
+        $ttl = $this->redis->ttl('session.12345&$%8');
+        $this->assertEquals($expectedttl, $ttl, '', 5);
+    }
+
+    public function test_set_no_expire() {
+        // Redis returns -1 for keys that have no TTL.
+        $expectedttl = -1;
+        $redisstore = new redis_store($this->redis);
+        $redisstore->set('session', 'g987654321', (object) ['k' => 'v', 'k2' => 'v2']);
+
+        $ttl = $this->redis->ttl('session.g987654321');
+        $this->assertEquals($expectedttl, $ttl);
+    }
+
+    public function test_get_key_exists() {
+        $redisstore = new redis_store($this->redis);
+
+        $value = (object) ['k' => 'v', 'k2' => 'v2'];
+        $redisstore->set('session', 'g98765', $value);
+
+        $this->assertEquals($value, $redisstore->get('session', 'g98765'));
+    }
+
+    public function test_get_key_not_exists() {
+        $redisstore = new redis_store($this->redis);
+
+        $this->assertNull($redisstore->get('session', 'nonexistentkey'));
+    }
+
+    public function test_delete() {
+        $redisstore = new redis_store($this->redis);
+
+        $redisstore->set('session', '12345-09', 'value');
+        $this->assertEquals('value', $redisstore->get('session', '12345-09'));
+
+        $redisstore->delete('session', '12345-09');
+        $this->assertNull($redisstore->get('session', '12345-09'));
+    }
+
+    public function test_delete_key_not_exists() {
+        $redisstore = new redis_store($this->redis);
+        $redisstore->delete('session', 'nonexistentkey');
+    }
+
+    public function test_bootstrap_redis() {
+        global $CFG;
+
+        $this->resetAfterTest(true);
+        $CFG->auth_saml2_redis_server = AUTH_SAML2_REDIS_STORE_TEST_SERVER;
+        $CFG->dbname = 'testdbname';
+
+        $value = (object) ['k' => 'v', 'k2' => 'v2'];
+        $redistore = new redis_store();
+        $redistore->set('session', 'key', $value);
+
+        $this->assertEquals($value, $redistore->get('session', 'key'));
+    }
+
+    /**
+     * Helper method to determine whether a Redis server is available to run these tests.
+     * If AUTH_SAML2_REDIS_STORE_TEST_SERVER is not set most of these tests will be skipped.
+     *
+     * @uses AUTH_SAML2_REDIS_STORE_TEST_SERVER
+     * @return bool
+     */
+    protected function is_redis_available() {
+        return defined('AUTH_SAML2_REDIS_STORE_TEST_SERVER');
+    }
+}

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2017081700;    // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2017081700;    // Match release exactly to version.
+$plugin->version   = 2017092701;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2017092701;    // Match release exactly to version.
 $plugin->requires  = 2014050800;    // Requires this Moodle version.
 $plugin->component = 'auth_saml2';  // Full name of the plugin (used for diagnostics).
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
This PR adds support for using Redis as the store type. It uses 2 new $CFG variables that can be set in Moodle's config.php: $CFG->auth_saml2_store and $CFG->auth_saml2_redis_server.

To use it you would add something like this to the config file:

$CFG->auth_saml2_store = '\\auth_saml2\\redis_store';
$CFG->auth_saml2_redis_server = '127.0.0.1';

To run PHPUnit tests, AUTH_SAML2_REDIS_STORE_TEST_SERVER must be defined in the Moodle config file, set to a Redis connection string.