### PR TITLE
auth_saml2: Allow the use of a discovery service URL

### DIFF
--- a/config/authsources.php
+++ b/config/authsources.php
@@ -36,7 +36,8 @@ $config = array(
     $saml2auth->spname => array(
         'saml:SP',
         'entityID' => "$wwwroot/auth/saml2/sp/metadata.php",
-        'idp' => $saml2auth->config->entityid,
+        'discoURL' => !empty($CFG->auth_saml2_disco_url) ? $CFG->auth_saml2_disco_url : null,
+        'idp' => empty($CFG->auth_saml2_disco_url) ? $saml2auth->config->entityid : null,
         'NameIDPolicy' => null,
         'OrganizationName' => array(
             'en' => $SITE->shortname,

--- a/extlib/simplesamlphp/www/module.php
+++ b/extlib/simplesamlphp/www/module.php
@@ -9,8 +9,6 @@
  * @package SimpleSAMLphp
  */
 
-require_once('_include.php');
-
 // index pages - file names to attempt when accessing directories
 $indexFiles = array('index.php', 'index.html', 'index.htm', 'index.txt');
 

--- a/sp/module.php
+++ b/sp/module.php
@@ -1,0 +1,33 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Module landing page.
+ *
+ * @package    auth_saml2
+ * @author     Sam Chaffee
+ * @copyright  Copyright (c) 2017 Blackboard Inc. (http://www.blackboard.com)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once('../setup.php');
+
+// Tell SSP that we are on 443 if we are terminating SSL elsewhere.
+if (!empty($CFG->sslproxy)) {
+    $_SERVER['SERVER_PORT'] = '443';
+}
+
+require($CFG->dirroot.'/auth/saml2/extlib/simplesamlphp/www/module.php');


### PR DESCRIPTION
This allows the use of a discovery service via a URL. As the changes are presented in this pull request the feature is enabled by setting $CFG->auth_saml2_disco_url to a string that is a URL for the discovery service being used.

When the above config is set the hosted SP discoURL config is set the value it holds and the hosted SP config idp is set to null (see https://simplesamlphp.org/docs/stable/saml:sp). When idp is null and the authentication process is started a discovery service operation is started.

We have plans to expose this via the auth_saml2 settings page in the future, but when we needed to implement this we were constrained to making non-UI changes only, hence the config.php setting.