### PR TITLE
Config setting to enable exposing NameID as attribute

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -50,6 +50,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
         'spmetadatasign'  => true,
         'showidplink'     => true,
         'alterlogout'     => '',
+        'nameidasattrib'  => 0,
     );
 
     /**

--- a/config/authsources.php
+++ b/config/authsources.php
@@ -51,6 +51,17 @@ $config = array(
         'sign.logout' => true,
         'redirect.sign' => true,
         'signature.algorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
-
     ),
 );
+/*
+ * If we're configured to expose the nameid as an attribute, set this authproc filter up
+ * the nameid value appears under the attribute "nameid"
+ */
+if ($saml2auth->config->nameidasattrib) {
+    $config[$saml2auth->spname]['authproc'] = array(
+        20 => array(
+            'class' => 'saml:NameIDAttribute',
+            'format' => '%V',
+        ),
+    );
+}

--- a/lang/en/auth_saml2.php
+++ b/lang/en/auth_saml2.php
@@ -85,6 +85,8 @@ $string['requireint'] = 'This field is required and needs to be a positive integ
 $string['regenerate_submit'] = 'Regenerate';
 $string['test_passive'] = '<a href="{$a}">Test using isPassive</a>';
 $string['test_auth'] = '<a href="{$a}">Test isAuthenticated and login</a>';
+$string['nameidasattrib'] = 'Expose NameID as attribute';
+$string['nameidasattrib_help'] = 'The NameID claim will be exposed to SSPHP as an attribute named nameid';
 
 $string['alterlogout'] = 'Alternative Logout URL';
 $string['alterlogout_help'] = 'The URL to redirect a user after all internal logout mechanisms are run';

--- a/settings.html
+++ b/settings.html
@@ -60,6 +60,13 @@ if(!function_exists('mcrypt_encrypt')) {
         <?php print_string($field.'_help', 'auth_saml2', "$CFG->wwwroot/auth/saml2/debug.php") ?></td>
 </tr>
 <tr valign="top">
+    <?php $field = 'nameidasattrib' ?>
+    <td align="right"><label for="<?php echo $field ?>"><?php print_string($field, 'auth_saml2') ?></label></td>
+    <td><?php echo html_writer::select($yesno, $field, $config->$field, false) ?>
+        <?php if (isset($err[$field])) { echo $OUTPUT->notification($err[$field], 'notifyfailure'); } ?>
+        <?php print_string($field.'_help', 'auth_saml2', "$CFG->wwwroot/auth/saml2/debug.php") ?></td>
+</tr>
+<tr valign="top">
     <?php $field = 'certificatelock' ?>
     <td align="right"><label for="<?php echo $field ?>"><?php print_string($field, 'auth_saml2') ?></label></td>
     <td>


### PR DESCRIPTION
Often for SSO the IDP will expose a NameID field only, so this
configuration setting will expose the NameID field as an attribute
'nameid' which can then be matched against for login

Fixes #144 