### PR TITLE
Config setting to enable exposing NameID as attribute (Moodle 3.3)

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -52,6 +52,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
         'alterlogout'     => '',
         'logtofile'       => 0,
         'logdir'          => '/tmp/',
+        'nameidasattrib'  => 0,
     );
 
     /**

--- a/config/authsources.php
+++ b/config/authsources.php
@@ -53,6 +53,17 @@ $config = array(
         'sign.logout' => true,
         'redirect.sign' => true,
         'signature.algorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
-
     ),
 );
+/*
+ * If we're configured to expose the nameid as an attribute, set this authproc filter up
+ * the nameid value appears under the attribute "nameid"
+ */
+if ($saml2auth->config->nameidasattrib) {
+    $config[$saml2auth->spname]['authproc'] = array(
+        20 => array(
+            'class' => 'saml:NameIDAttribute',
+            'format' => '%V',
+        ),
+    );
+}

--- a/lang/en/auth_saml2.php
+++ b/lang/en/auth_saml2.php
@@ -93,6 +93,8 @@ $string['requireint'] = 'This field is required and needs to be a positive integ
 $string['regenerate_submit'] = 'Regenerate';
 $string['test_passive'] = '<a href="{$a}">Test using isPassive</a>';
 $string['test_auth'] = '<a href="{$a}">Test isAuthenticated and login</a>';
+$string['nameidasattrib'] = 'Expose NameID as attribute';
+$string['nameidasattrib_help'] = 'The NameID claim will be exposed to SSPHP as an attribute named nameid';
 
 $string['alterlogout'] = 'Alternative Logout URL';
 $string['alterlogout_help'] = 'The URL to redirect a user after all internal logout mechanisms are run';

--- a/settings.php
+++ b/settings.php
@@ -88,6 +88,12 @@ if ($ADMIN->fulltree) {
             get_string('logdirdefault', 'auth_saml2'),
             PARAM_TEXT));
 
+    // Add NameID as attribute.
+    $settings->add(new admin_setting_configselect(
+            'auth_saml2/nameidasattrib',
+            get_string('nameidasattrib', 'auth_saml2'),
+            get_string('nameidasattrib_help', 'auth_saml2'),
+            0, $yesno));
 
     // Lock certificate.
     $settings->add(new admin_setting_auth_saml2_button(


### PR DESCRIPTION
Often for SSO the IDP will expose a NameID field only, so this
configuration setting will expose the NameID field as an attribute
'nameid' which can then be matched against for login