### PR TITLE
Respect moodle proxy settings on IdP metadata fetch.

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -485,7 +485,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
             // If rawxml looks like a url, then go scrape it first.
             if (substr($rawxml, 0, 8) == 'https://' ||
                 substr($rawxml, 0, 7) == 'http://') {
-                $rawxml = @file_get_contents($rawxml);
+                $rawxml = @download_file_content($rawxml);
 
                 if (!$rawxml) {
                     $err['idpmetadata'] = get_string('idpmetadata_badurl', 'auth_saml2');


### PR DESCRIPTION
When fetching IdP metadata from remote systems (http(s):// link in "IdP metadata xml OR public xml URL" configuration option), download_file_content function should be used, instead of file_get_contents that does not respect moodle proxy settings