### PR TITLE
Fixes #214 - Removing splat operator introduced in php 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,14 @@ cache:
 # Alternate tests with MySQL and PostgreSQL
 matrix:
   include:
-    # PHP 5.6
-    - php: 5.6
+    # PHP 5.5
+    - php: 5.5
       env: DB=pgsql  MOODLE_BRANCH=MOODLE_27_STABLE
-    - php: 5.6
+    - php: 5.5
       env: DB=mysqli MOODLE_BRANCH=MOODLE_28_STABLE
-    - php: 5.6
+    - php: 5.5
       env: DB=pgsql  MOODLE_BRANCH=MOODLE_29_STABLE
+    # PHP 5.6
     - php: 5.6
       env: DB=mysqli MOODLE_BRANCH=MOODLE_30_STABLE
     - php: 5.6

--- a/tests/behat/behat_auth_saml2.php
+++ b/tests/behat/behat_auth_saml2.php
@@ -231,6 +231,6 @@ class behat_auth_saml2 extends behat_base {
         list($class, $method) = explode("::", $contextapi);
         $object = behat_context_helper::get($class);
         $object->setMinkParameter('base_url', $CFG->wwwroot);
-        return $object->$method(...$params);
+        return call_user_func_array([$object, $method], $params);
     }
 }


### PR DESCRIPTION
Also put some tests to run with 5.5 which would have detected that. See also #213 .