### PR TITLE
Issue #228 - regenerate sp metadata on nameidpolicy change

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -286,8 +286,7 @@ function auth_saml2_get_sp_metadata() {
 function auth_saml2_update_sp_metadata() {
     global $saml2auth;
 
-    // Remove the cached metadata so the next call will have the latest metadata.
-    $file = $saml2auth->certdir . $saml2auth->spname . '.xml';
+    $file = $saml2auth->get_file_sp_metadata_file();
     @unlink($file);
 }
 

--- a/locallib.php
+++ b/locallib.php
@@ -278,6 +278,20 @@ function auth_saml2_get_sp_metadata() {
 }
 
 /**
+ * Used for adminlib::set_updatedcallback which requires a string that resolves to a function.
+ *
+ * Refreshes the sp metadata as some metadata has been updated.
+ *
+ */
+function auth_saml2_update_sp_metadata() {
+    global $saml2auth;
+
+    // Remove the cached metadata so the next call will have the latest metadata.
+    $file = $saml2auth->certdir . $saml2auth->spname . '.xml';
+    @unlink($file);
+}
+
+/**
  * Helper function used to print locking for auth plugins on admin pages.
  * @param stdclass $settings Moodle admin settings instance
  * @param string $auth authentication plugin shortname

--- a/settings.php
+++ b/settings.php
@@ -110,12 +110,14 @@ if ($ADMIN->fulltree) {
         'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
         'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
     ];
-    $settings->add(new admin_setting_configselect(
+    $nameidpolicy = new admin_setting_configselect(
         'auth_saml2/nameidpolicy',
         get_string('nameidpolicy', 'auth_saml2'),
         get_string('nameidpolicy_help', 'auth_saml2'),
         'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
-        array_combine($nameidlist, $nameidlist)));
+        array_combine($nameidlist, $nameidlist));
+    $nameidpolicy->set_updatedcallback('auth_saml2_update_sp_metadata');
+    $settings->add($nameidpolicy);
 
     // Add NameID as attribute.
     $settings->add(new admin_setting_configselect(


### PR DESCRIPTION
Currently when changing the nameidpolicy the sp metadata will not regenerate until forced. This change fixes that so the sp metadata is forced to regenerate when the nameidpolicy is changed.