### PR TITLE
receiving contextual and set_urls when saml has timed-out

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -412,6 +412,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
         if (empty($attributes[$attr]) ) {
             $this->error_page(get_string('noattribute', 'auth_saml2', $attr));
         }
+        $PAGE->set_context(context_system::instance());
 
         $user = null;
         foreach ($attributes[$attr] as $key => $uid) {
@@ -465,6 +466,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
         // If we are not on the page we want, then redirect to it.
         if ( qualified_me() !== $urltogo ) {
             $this->log(__FUNCTION__ . " redirecting to $urltogo");
+            $PAGE->set_url($urltogo);
             redirect($urltogo);
             exit;
         } else {

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2018032900;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 20180531000;    // The current plugin version (Date: YYYYMMDDXX).
 $plugin->release   = 2018032900;    // Match release exactly to version.
 $plugin->requires  = 2014051200;    // Requires this Moodle version. (2.7)
 $plugin->component = 'auth_saml2';  // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
- improve string contextualization (namely related to profile_field context) to remove "Coding problem $PAGE->context was not set." at line 433. 
- append set_url prior to redirect to remove the "This page did not call $PAGE->set_url..." error at line 458
