### PR TITLE
Adding a setting for signing algorithm, defaulting it to sha256

### DIFF
--- a/classes/ssl_algorithms.php
+++ b/classes/ssl_algorithms.php
@@ -1,0 +1,68 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+  * @package    auth_saml2
+  * @author     Adam Lynam <adam.lynam@catalyst.net.nz>
+  * @copyright  Catalyst IT
+  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+  */
+
+namespace auth_saml2;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $saml2auth;
+
+abstract class ssl_algorithms {
+  /*
+   * Return a sensible default signature algorithm for simplesamlphp config
+   */
+  public static function get_default_saml_signature_algorithm() {
+      //Sha1 is deprecated so we default to something more sensible
+      return 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
+  }
+
+  /*
+   * Return an array of signature algorithms in a form suitable for feeding into a dropdown form
+   */
+  public static function get_valid_saml_signature_algorithms() {
+      $return = array();
+      $return['http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'] = get_string('sha256', 'auth_saml2');
+      $return['http://www.w3.org/2001/04/xmldsig-more#rsa-sha384'] = get_string('sha384', 'auth_saml2');
+      $return['http://www.w3.org/2001/04/xmldsig-more#rsa-sha512'] = get_string('sha512', 'auth_saml2');
+      $return['http://www.w3.org/2000/09/xmldsig#rsa-sha1'] = get_string('sha1', 'auth_saml2');
+      return $return;
+  }
+
+  /*
+   * Return an array of digest algorithms in a form suitable for feeding into a dropdown form
+   */
+  public static function convert_signature_algorithm_to_digest_alg_format($signature_algorithm) {
+      switch($signature_algorithm) {
+          case 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256':
+              return 'SHA256';
+          case 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha384':
+              return 'SHA384';
+          case 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512':
+              return 'SHA512';
+          case 'http://www.w3.org/2000/09/xmldsig#rsa-sha1':
+              return 'SHA1';
+      }
+
+      return 'SHA256';
+  }
+}

--- a/classes/ssl_algorithms.php
+++ b/classes/ssl_algorithms.php
@@ -15,11 +15,11 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
-  * @package    auth_saml2
-  * @author     Adam Lynam <adam.lynam@catalyst.net.nz>
-  * @copyright  Catalyst IT
-  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
-  */
+ * @package    auth_saml2
+ * @author     Adam Lynam <adam.lynam@catalyst.net.nz>
+ * @copyright  Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
 namespace auth_saml2;
 
@@ -28,41 +28,41 @@ defined('MOODLE_INTERNAL') || die();
 global $saml2auth;
 
 abstract class ssl_algorithms {
-  /*
-   * Return a sensible default signature algorithm for simplesamlphp config
-   */
-  public static function get_default_saml_signature_algorithm() {
-      //Sha1 is deprecated so we default to something more sensible
-      return 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
-  }
+   /*
+    * Return a sensible default signature algorithm for simplesamlphp config.
+    */
+    public static function get_default_saml_signature_algorithm() {
+        //Sha1 is deprecated so we default to something more sensible
+        return 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
+    }
 
-  /*
-   * Return an array of signature algorithms in a form suitable for feeding into a dropdown form
-   */
-  public static function get_valid_saml_signature_algorithms() {
-      $return = array();
-      $return['http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'] = get_string('sha256', 'auth_saml2');
-      $return['http://www.w3.org/2001/04/xmldsig-more#rsa-sha384'] = get_string('sha384', 'auth_saml2');
-      $return['http://www.w3.org/2001/04/xmldsig-more#rsa-sha512'] = get_string('sha512', 'auth_saml2');
-      $return['http://www.w3.org/2000/09/xmldsig#rsa-sha1'] = get_string('sha1', 'auth_saml2');
-      return $return;
-  }
+   /*
+    * Return an array of signature algorithms in a form suitable for feeding into a dropdown form.
+    */
+    public static function get_valid_saml_signature_algorithms() {
+        $return = array();
+        $return['http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'] = get_string('sha256', 'auth_saml2');
+        $return['http://www.w3.org/2001/04/xmldsig-more#rsa-sha384'] = get_string('sha384', 'auth_saml2');
+        $return['http://www.w3.org/2001/04/xmldsig-more#rsa-sha512'] = get_string('sha512', 'auth_saml2');
+        $return['http://www.w3.org/2000/09/xmldsig#rsa-sha1'] = get_string('sha1', 'auth_saml2');
+        return $return;
+    }
 
-  /*
-   * Return an array of digest algorithms in a form suitable for feeding into a dropdown form
-   */
-  public static function convert_signature_algorithm_to_digest_alg_format($signature_algorithm) {
-      switch($signature_algorithm) {
-          case 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256':
-              return 'SHA256';
-          case 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha384':
-              return 'SHA384';
-          case 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512':
-              return 'SHA512';
-          case 'http://www.w3.org/2000/09/xmldsig#rsa-sha1':
-              return 'SHA1';
-      }
+   /*
+    * Return an array of digest algorithms in a form suitable for feeding into a dropdown form.
+    */
+    public static function convert_signature_algorithm_to_digest_alg_format($signature_algorithm) {
+        switch($signature_algorithm) {
+            case 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256':
+                return 'SHA256';
+            case 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha384':
+                return 'SHA384';
+            case 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512':
+                return 'SHA512';
+            case 'http://www.w3.org/2000/09/xmldsig#rsa-sha1':
+                return 'SHA1';
+        }
 
-      return 'SHA256';
-  }
+        return 'SHA256';
+    }
 }

--- a/classes/ssl_algorithms.php
+++ b/classes/ssl_algorithms.php
@@ -28,17 +28,17 @@ defined('MOODLE_INTERNAL') || die();
 global $saml2auth;
 
 abstract class ssl_algorithms {
-   /*
-    * Return a sensible default signature algorithm for simplesamlphp config.
-    */
+    /*
+     * Return a sensible default signature algorithm for simplesamlphp config.
+     */
     public static function get_default_saml_signature_algorithm() {
-        //Sha1 is deprecated so we default to something more sensible
+        // Sha1 is deprecated so we default to something more sensible.
         return 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
     }
 
-   /*
-    * Return an array of signature algorithms in a form suitable for feeding into a dropdown form.
-    */
+    /*
+     * Return an array of signature algorithms in a form suitable for feeding into a dropdown form.
+     */
     public static function get_valid_saml_signature_algorithms() {
         $return = array();
         $return['http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'] = get_string('sha256', 'auth_saml2');
@@ -48,11 +48,11 @@ abstract class ssl_algorithms {
         return $return;
     }
 
-   /*
-    * Return an array of digest algorithms in a form suitable for feeding into a dropdown form.
-    */
-    public static function convert_signature_algorithm_to_digest_alg_format($signature_algorithm) {
-        switch($signature_algorithm) {
+    /*
+     * Return an array of digest algorithms in a form suitable for feeding into a dropdown form.
+     */
+    public static function convert_signature_algorithm_to_digest_alg_format($signaturealgorithm) {
+        switch($signaturealgorithm) {
             case 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256':
                 return 'SHA256';
             case 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha384':

--- a/config/authsources.php
+++ b/config/authsources.php
@@ -22,6 +22,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use auth_saml2\ssl_signing_algorithm;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $saml2auth, $CFG, $SITE, $SESSION;
@@ -93,7 +95,7 @@ $config[$saml2auth->spname] = [
     'certificate' => $saml2auth->spname . '.crt',
     'sign.logout' => true,
     'redirect.sign' => true,
-    'signature.algorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+    'signature.algorithm' => $saml2auth->config->signaturealgorithm,
 ];
 
 /*

--- a/config/config.php
+++ b/config/config.php
@@ -22,7 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use auth_saml2\ssl_signing_algorithm;
+ use auth_saml2\ssl_algorithms;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -84,7 +84,7 @@ $config = array(
 
     'enable.http_post' => false,
 
-    'signature.algorithm' => $saml2auth->config->signaturealgorithm,
+    'signature.algorithm' => !empty($saml2auth->config->signaturealgorithm) ? $saml2auth->config->signaturealgorithm : ssl_algorithms::get_default_saml_signature_algorithm(),
 
     'metadata.sign.enable'          => $saml2auth->config->spmetadatasign ? true : false,
     'metadata.sign.certificate'     => $saml2auth->certcrt,

--- a/config/config.php
+++ b/config/config.php
@@ -22,6 +22,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use auth_saml2\ssl_signing_algorithm;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG, $saml2auth;
@@ -81,6 +83,8 @@ $config = array(
     'session.phpsession.httponly'   => true,
 
     'enable.http_post' => false,
+
+    'signature.algorithm' => $saml2auth->config->signaturealgorithm,
 
     'metadata.sign.enable'          => $saml2auth->config->spmetadatasign ? true : false,
     'metadata.sign.certificate'     => $saml2auth->certcrt,

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -204,6 +204,7 @@ function xmldb_auth_saml2_upgrade($oldversion) {
 
     if ($oldversion < 2018071100) {
         set_config('signaturealgorithm', ssl_algorithms::get_default_saml_signature_algorithm(), 'auth_saml2');
+        upgrade_plugin_savepoint(true, 2018071100, 'auth', 'saml2');
     }
 
     return true;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -23,6 +23,7 @@
  */
 
 use auth_saml2\task\metadata_refresh;
+use auth_saml2\ssl_algorithms;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -199,6 +200,10 @@ function xmldb_auth_saml2_upgrade($oldversion) {
         $table = new xmldb_table('auth_samltwo_kvstore');
         $dbman->rename_table($table, 'auth_saml2_kvstore');
         upgrade_plugin_savepoint(true, 2018030800, 'auth', 'saml2');
+    }
+
+    if ($oldversion < 2018071100) {
+        set_config('signaturealgorithm', ssl_algorithms::get_default_saml_signature_algorithm(), 'auth_saml2');
     }
 
     return true;

--- a/lang/en/auth_saml2.php
+++ b/lang/en/auth_saml2.php
@@ -140,3 +140,13 @@ $string['nameidpolicy_help'] = '';
  * Privacy provider (GDPR)
  */
 $string["privacy:no_data_reason"] = "The Saml2 authentication plugin does not store any personal data.";
+
+/*
+ * Signing Algorithm
+ */
+$string['sha1'] = 'Legacy SHA1 (Dangerous)';
+$string['sha256'] = 'SHA256';
+$string['sha384'] = 'SHA384';
+$string['sha512'] = 'SHA512';
+$string['signaturealgorithm'] = 'Signing Algorithm';
+$string['signaturealgorithm_help'] = 'This is the algorithm that will be used to sign SAML requests. Warning: The SHA1 Algorithm is only provided for backwards compatibility, unless you absolutely must use it it is recommended to avoid it and use at least SHA256 instead.';

--- a/settings.php
+++ b/settings.php
@@ -25,6 +25,7 @@
 use auth_saml2\admin\saml2_settings;
 use auth_saml2\admin\setting_button;
 use auth_saml2\admin\setting_textonly;
+use auth_saml2\ssl_algorithms;
 
 defined('MOODLE_INTERNAL') || die;
 
@@ -145,6 +146,13 @@ if ($ADMIN->fulltree) {
             get_string('spmetadatasign', 'auth_saml2'),
             get_string('spmetadatasign_help', 'auth_saml2'),
             0, $yesno));
+
+    $settings->add(new admin_setting_configselect(
+        'auth_saml2/signaturealgorithm',
+        get_string('signaturealgorithm', 'auth_saml2'),
+        get_string('signaturealgorithm_help', 'auth_saml2'),
+        ssl_algorithms::get_default_saml_signature_algorithm(),
+        ssl_algorithms::get_valid_saml_signature_algorithms()));
 
     // Dual Login.
     $dualloginoptions = [

--- a/setuplib.php
+++ b/setuplib.php
@@ -43,10 +43,13 @@ require_once("{$CFG->dirroot}/auth/saml2/auth.php");
 function create_certificates($saml2auth, $dn = false, $numberofdays = 3650) {
     global $SITE;
 
-    $opensslargs = array();
-    $opensslargs['digest_alg'] = isset($saml2auth->config->signaturealgorithm)
-            ? ssl_algorithms::convert_signature_algorithm_to_digest_alg_format($saml2auth->config->signaturealgorithm)
-            : ssl_algorithms::convert_signature_algorithm_to_digest_alg_format(ssl_algorithms::get_default_saml_signature_algorithm());
+    $signaturealgorithm = ssl_algorithms::get_default_saml_signature_algorithm();
+    if (isset($saml2auth->config->signaturealgorithm)) {
+        $signaturealgorithm = $saml2auth->config->signaturealgorithm;
+    }
+    $opensslargs = array(
+      'digest_alg' => ssl_algorithms::convert_signature_algorithm_to_digest_alg_format($signaturealgorithm),
+    );
     if (array_key_exists('OPENSSL_CONF', $_SERVER)) {
         $opensslargs['config'] = $_SERVER['OPENSSL_CONF'];
     }

--- a/setuplib.php
+++ b/setuplib.php
@@ -44,9 +44,9 @@ function create_certificates($saml2auth, $dn = false, $numberofdays = 3650) {
     global $SITE;
 
     $opensslargs = array();
-    $opensslargs['digest_alg'] = isset($saml2auth->config->signaturealgorithm) ? 
-            ssl_algorithms::convert_signature_algorithm_to_digest_alg_format($saml2auth->config->signaturealgorithm) : 
-            ssl_algorithms::convert_signature_algorithm_to_digest_alg_format(ssl_algorithms::get_default_saml_signature_algorithm());
+    $opensslargs['digest_alg'] = isset($saml2auth->config->signaturealgorithm)
+            ? ssl_algorithms::convert_signature_algorithm_to_digest_alg_format($saml2auth->config->signaturealgorithm)
+            : ssl_algorithms::convert_signature_algorithm_to_digest_alg_format(ssl_algorithms::get_default_saml_signature_algorithm());
     if (array_key_exists('OPENSSL_CONF', $_SERVER)) {
         $opensslargs['config'] = $_SERVER['OPENSSL_CONF'];
     }

--- a/setuplib.php
+++ b/setuplib.php
@@ -44,8 +44,8 @@ function create_certificates($saml2auth, $dn = false, $numberofdays = 3650) {
     global $SITE;
 
     $opensslargs = array();
-    $opensslargs['digest_alg'] = isset($saml2auth->config->signaturealgorithm) ?
-            ssl_algorithms::convert_signature_algorithm_to_digest_alg_format($saml2auth->config->signaturealgorithm) :
+    $opensslargs['digest_alg'] = isset($saml2auth->config->signaturealgorithm) ? 
+            ssl_algorithms::convert_signature_algorithm_to_digest_alg_format($saml2auth->config->signaturealgorithm) : 
             ssl_algorithms::convert_signature_algorithm_to_digest_alg_format(ssl_algorithms::get_default_saml_signature_algorithm());
     if (array_key_exists('OPENSSL_CONF', $_SERVER)) {
         $opensslargs['config'] = $_SERVER['OPENSSL_CONF'];

--- a/setuplib.php
+++ b/setuplib.php
@@ -44,7 +44,9 @@ function create_certificates($saml2auth, $dn = false, $numberofdays = 3650) {
     global $SITE;
 
     $opensslargs = array();
-    $opensslargs['digest_alg'] = ssl_algorithms::convert_signature_algorithm_to_digest_alg_format($saml2auth->config->signaturealgorithm);
+    $opensslargs['digest_alg'] = isset($saml2auth->config->signaturealgorithm) ?
+        ssl_algorithms::convert_signature_algorithm_to_digest_alg_format($saml2auth->config->signaturealgorithm) :
+        ssl_algorithms::convert_signature_algorithm_to_digest_alg_format(ssl_algorithms::get_default_saml_signature_algorithm());
     if (array_key_exists('OPENSSL_CONF', $_SERVER)) {
         $opensslargs['config'] = $_SERVER['OPENSSL_CONF'];
     }

--- a/setuplib.php
+++ b/setuplib.php
@@ -45,8 +45,8 @@ function create_certificates($saml2auth, $dn = false, $numberofdays = 3650) {
 
     $opensslargs = array();
     $opensslargs['digest_alg'] = isset($saml2auth->config->signaturealgorithm) ?
-        ssl_algorithms::convert_signature_algorithm_to_digest_alg_format($saml2auth->config->signaturealgorithm) :
-        ssl_algorithms::convert_signature_algorithm_to_digest_alg_format(ssl_algorithms::get_default_saml_signature_algorithm());
+            ssl_algorithms::convert_signature_algorithm_to_digest_alg_format($saml2auth->config->signaturealgorithm) :
+            ssl_algorithms::convert_signature_algorithm_to_digest_alg_format(ssl_algorithms::get_default_saml_signature_algorithm());
     if (array_key_exists('OPENSSL_CONF', $_SERVER)) {
         $opensslargs['config'] = $_SERVER['OPENSSL_CONF'];
     }

--- a/setuplib.php
+++ b/setuplib.php
@@ -22,6 +22,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use auth_saml2\ssl_algorithms;
+
 require_once(__DIR__ . '/../../config.php');
 require_once(__DIR__ . '/_autoload.php');
 
@@ -42,6 +44,7 @@ function create_certificates($saml2auth, $dn = false, $numberofdays = 3650) {
     global $SITE;
 
     $opensslargs = array();
+    $opensslargs['digest_alg'] = ssl_algorithms::convert_signature_algorithm_to_digest_alg_format($saml2auth->config->signaturealgorithm);
     if (array_key_exists('OPENSSL_CONF', $_SERVER)) {
         $opensslargs['config'] = $_SERVER['OPENSSL_CONF'];
     }
@@ -170,4 +173,3 @@ class saml2_exception extends moodle_exception {
         parent::__construct('exception', 'auth_saml2', '', htmlspecialchars($a), $debuginfo);
     }
 }
-

--- a/setuplib.php
+++ b/setuplib.php
@@ -44,7 +44,7 @@ function create_certificates($saml2auth, $dn = false, $numberofdays = 3650) {
     global $SITE;
 
     $signaturealgorithm = ssl_algorithms::get_default_saml_signature_algorithm();
-    if (isset($saml2auth->config->signaturealgorithm)) {
+    if (!empty($saml2auth->config->signaturealgorithm)) {
         $signaturealgorithm = $saml2auth->config->signaturealgorithm;
     }
     $opensslargs = array(

--- a/tests/phpunit/ssl_algorithm_test.php
+++ b/tests/phpunit/ssl_algorithm_test.php
@@ -1,0 +1,44 @@
+<?php
+// This file is part of SAML2 Authentication Plugin
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package    auth_saml2
+ * @author     Adam Lynam <adam.lynam@catalyst.net.nz>
+ * @copyright  Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use auth_saml2\ssl_algorithms;
+
+defined('MOODLE_INTERNAL') || die();
+
+class auth_saml2_ssl_algorithms_test extends basic_testcase {
+    public function test_default_saml_signature_algorithm_is_valid_saml_signature_algorithm() {
+        $this->assertTrue(array_key_exists(ssl_algorithms::get_default_saml_signature_algorithm(), ssl_algorithms::get_valid_saml_signature_algorithms()));
+    }
+
+    public function test_sha256_is_valid_saml_signature_algorithm() {
+        $this->assertTrue(array_key_exists('http://www.w3.org/2001/04/xmldsig-more#rsa-sha256', ssl_algorithms::get_valid_saml_signature_algorithms()));
+    }
+
+    public function test_sha256_is_matching_digest_algorithm_for_default_saml_algorithm() {
+        $this->assertEquals('SHA256', ssl_algorithms::convert_signature_algorithm_to_digest_alg_format(ssl_algorithms::get_default_saml_signature_algorithm()));
+    }
+
+    public function test_sha256_is_matching_digest_algorithm_for_garbage_algorithm() {
+        $this->assertEquals('SHA256', ssl_algorithms::convert_signature_algorithm_to_digest_alg_format('garbage nonsense'));
+    }
+}

--- a/version.php
+++ b/version.php
@@ -24,9 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2018070200;    // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2018070200;    // Match release exactly to version.
+$plugin->version   = 2018071100;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2018071100;    // Match release exactly to version.
 $plugin->requires  = 2014051200;    // Requires this Moodle version. (2.7)
 $plugin->component = 'auth_saml2';  // Full name of the plugin (used for diagnostics).
 $plugin->maturity  = MATURITY_STABLE;
-


### PR DESCRIPTION
Essentially a Moodlfied version of:

https://github.com/MaharaProject/mahara/commit/059b0765e4ce6867cccfda3c6b1d5426fe2c878d#diff-0e96462bae3baa9606309828e2638802

I should make it clear, this exposes one setting that controls both the signing algorithm for the service provider and the digest algorithm for generating self-signed certificates for the service provider.