### PR TITLE
idp empty string fix & $PAGE context fixes

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -428,7 +428,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
     public function saml_login() {
 
         // @codingStandardsIgnoreStart
-        global $CFG, $DB, $USER, $SESSION, $saml2auth;
+        global $CFG, $DB, $USER, $SESSION, $PAGE, $saml2auth;
         // @codingStandardsIgnoreEnd
 
         require('setup.php');
@@ -484,6 +484,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
             $this->error_page(get_string('noattribute', 'auth_saml2', $attr));
         }
 
+        $PAGE->set_context(context_system::instance());
         $user = null;
         foreach ($attributes[$attr] as $key => $uid) {
             if ($this->config->tolower) {
@@ -536,6 +537,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
         // If we are not on the page we want, then redirect to it.
         if ( qualified_me() !== $urltogo ) {
             $this->log(__FUNCTION__ . " redirecting to $urltogo");
+            $PAGE->set_url($urltogo);
             redirect($urltogo);
             exit;
         } else {
@@ -785,4 +787,3 @@ class auth_plugin_saml2 extends auth_plugin_base {
         }
     }
 }
-

--- a/classes/idp_parser.php
+++ b/classes/idp_parser.php
@@ -76,45 +76,47 @@ class idp_parser {
         $lines = preg_split('#\R#', $urls);
 
         foreach ($lines as $line) {
-            $idpdata = null;
-            $scheme = 'http';
+            if (trim($line) !== '') {
+                $idpdata = null;
+                $scheme = 'http';
 
-            // Separate the line base on the scheme http. The scheme added back to the urls.
-            $parts = array_map('rtrim', explode($scheme, $line));
+                // Separate the line base on the scheme http. The scheme added back to the urls.
+                $parts = array_map('rtrim', explode($scheme, $line));
 
-            if (count($parts) === 3) {
-                // With three elements I will assume that it was entered in the correct format.
-                $idpname = $parts[0];
-                $idpurl = $scheme . $parts[1];
-                $idpicon = $scheme . $parts[2];
-
-                $idpdata = new \auth_saml2\idp_data($idpname, $idpurl, $idpicon);
-
-            } else if (count($parts) === 2) {
-                // Two elements could either be a IdPName + IdPURL, or IdPURL + IdPIcon.
-
-                // Detect if $parts[0] starts with a URL.
-                if (substr($parts[0], 0, 8) === 'https://' ||
-                    substr($parts[0], 0, 7) === 'http://') {
+                if (count($parts) === 3) {
+                    // With three elements I will assume that it was entered in the correct format.
+                    $idpname = $parts[0];
                     $idpurl = $scheme . $parts[1];
                     $idpicon = $scheme . $parts[2];
 
-                    $idpdata = new \auth_saml2\idp_data(null, $idpurl, $idpicon);
-                } else {
-                    // We would then know that is a IdPName + IdPURL combo.
-                    $idpname = $parts[0];
-                    $idpurl = $scheme . $parts[1];
+                    $idpdata = new \auth_saml2\idp_data($idpname, $idpurl, $idpicon);
 
-                    $idpdata = new \auth_saml2\idp_data($idpname, $idpurl, null);
+                } else if (count($parts) === 2) {
+                    // Two elements could either be a IdPName + IdPURL, or IdPURL + IdPIcon.
+
+                    // Detect if $parts[0] starts with a URL.
+                    if (substr($parts[0], 0, 8) === 'https://' ||
+                        substr($parts[0], 0, 7) === 'http://') {
+                        $idpurl = $scheme . $parts[1];
+                        $idpicon = $scheme . $parts[2];
+
+                        $idpdata = new \auth_saml2\idp_data(null, $idpurl, $idpicon);
+                    } else {
+                        // We would then know that is a IdPName + IdPURL combo.
+                        $idpname = $parts[0];
+                        $idpurl = $scheme . $parts[1];
+
+                        $idpdata = new \auth_saml2\idp_data($idpname, $idpurl, null);
+                    }
+
+                } else if (count($parts) === 1) {
+                    // One element is the previous default.
+                    $idpurl = $scheme . $parts[0];
+                    $idpdata = new \auth_saml2\idp_data(null, $idpurl, null);
                 }
 
-            } else if (count($parts) === 1) {
-                // One element is the previous default.
-                $idpurl = $scheme . $parts[0];
-                $idpdata = new \auth_saml2\idp_data(null, $idpurl, null);
+                $this->idps[] = $idpdata;
             }
-
-            $this->idps[] = $idpdata;
         }
     }
 }

--- a/classes/idp_parser.php
+++ b/classes/idp_parser.php
@@ -115,7 +115,9 @@ class idp_parser {
                     $idpdata = new \auth_saml2\idp_data(null, $idpurl, null);
                 }
 
-                $this->idps[] = $idpdata;
+                if ($idpurl !== 'http') {
+                    $this->idps[] = $idpdata;
+                }
             }
         }
     }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2018112800;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2018121300;    // The current plugin version (Date: YYYYMMDDXX).
 $plugin->release   = 2018112800;    // Match release exactly to version.
 $plugin->requires  = 2014051200;    // Requires this Moodle version. (2.7)
 $plugin->component = 'auth_saml2';  // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
there are two problems wrapped up in here one is that $PAGE context can have strange results IF the PAGE requested requires context settings

Second, is that if the IDP line is empty then the system tracks it as a valid IDP value for processing. There are two tracks here in idp_parser, one is if the line is EMPTY the second is if the idpurl is exactly http (as it should be a FQDN not just an empty address).

