### PR TITLE
Do not hash idp entity data when session data is not set

### DIFF
--- a/config/authsources.php
+++ b/config/authsources.php
@@ -40,7 +40,7 @@ $config = [];
 $arr = array_reverse($saml2auth->metadataentities);
 $metadataentities = array_pop($arr);
 $idpentity = array_pop($metadataentities);
-$idp = md5($idpentity->entityid);
+$idp = $idpentity->entityid;
 
 if (!empty($SESSION->saml2idp)) {
     foreach ($saml2auth->metadataentities as $idpentities) {


### PR DESCRIPTION
  - Issue #338 
We didn't hash this retrieved idp entity data before the multiple idp changes: https://github.com/catalyst/moodle-auth_saml2/blob/0defa84f3ba212577e512700f696ecc0a9ec2212/config/authsources.php#L41

But now we are hashing with md5, which causes issues. To see the problem with the master branch of the plugin:

1. Refresh the saml login page -- adds idp entity to session data
2. Clear browser data -- remove this session data
3. Login with saml auth credentials

You will see the following error: 

> SAML2 exception: Cannot retrieve metadata for IdP 'http://...' because it isn't a valid IdP for this SP.

This change fixes the above workflow and prevents this error.