### PR TITLE
Cannot retrieve metadata for IdP Issue #338

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -458,9 +458,11 @@ class auth_plugin_saml2 extends auth_plugin_base {
         // Fallback in case we can't get the idp from the url param or our session idp is empty.
         // Set the default IdP to be the first in the list. Used when dual login is disabled.
         $fallbackidp = auth_saml2_get_fallback_idp();
-        if (!is_null($fallbackidp)) {
-            $SESSION->saml2idp = md5(auth_saml2_get_fallback_idp()->entityid);
+        if (is_null($fallbackidp)) {
+            // We should already have checked for $fallbackidp === null in the is_configured() function
+            throw new coding_exception('Fallback idp cannot be null in saml_login function');
         }
+        $SESSION->saml2idp = $fallbackidp->entityid;
         $idpfromparam = optional_param('idp', '', PARAM_TEXT);
         if (!empty($idpfromparam)) {
             $SESSION->saml2idp = $idpfromparam;
@@ -484,7 +486,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
             if (!$idpfound) {
                 $this->error_page(get_string('noidpfound', 'auth_saml2', $idpalias));
             }
-        } else if ($idpfromparam) {
+        } else if (!empty($idpfromparam)) {
             $SESSION->saml2idp = $idpfromparam;
         } else if (!is_null($saml2auth->defaultidp)) {
             $SESSION->saml2idp = md5($saml2auth->defaultidp->entityid);

--- a/auth.php
+++ b/auth.php
@@ -462,15 +462,8 @@ class auth_plugin_saml2 extends auth_plugin_base {
 
         // Backup in case we can't get the idp from the url param or our session idp is empty.
         // Set the default IdP to be the first in the list. Used when dual login is disabled.
-        if (!$SESSION->saml2idp) {
-            // Set the default IdP to be the first in the list. Used when dual login is disabled.
-            $arr = array_reverse($saml2auth->metadataentities);
-            $metadataentities = array_pop($arr);
-            $idpentity = array_pop($metadataentities);
-            $idp = $idpentity->entityid;
-
-            // Specify the default IdP to use.
-            $SESSION->saml2idp = $idp;
+        if (empty($SESSION->saml2idp)) {
+            $SESSION->saml2idp = auth_saml2_get_default_idp();
         }
 
         // We store the IdP in the session to generate the config/config.php array with the default local SP.
@@ -491,9 +484,8 @@ class auth_plugin_saml2 extends auth_plugin_base {
             if (!$idpfound) {
                 $this->error_page(get_string('noidpfound', 'auth_saml2', $idpalias));
             }
-        } else if (!is_null($saml2auth->defaultidp)) {
-            $SESSION->saml2idp = md5($saml2auth->defaultidp->entityid);
-        } else if ($saml2auth->multiidp) {
+        }
+        if ($saml2auth->multiidp) {
             $idpurl = new moodle_url('/auth/saml2/selectidp.php');
             redirect($idpurl);
         }

--- a/classes/form/selectidp_buttons.php
+++ b/classes/form/selectidp_buttons.php
@@ -49,11 +49,12 @@ class selectidp_buttons extends moodleform {
 
         $metadataentities = $this->_customdata['metadataentities'];
         $defaultidp = $this->_customdata['defaultidp'];
-        $wants = $this->_customdata['wants'];
 
+        $wants = $this->_customdata['wants'];
         $mform->addElement('hidden', 'wants', $wants);
-        $mform->addElement('checkbox', 'rememberidp' , '', get_string('rememberidp', 'auth_saml2'));
         $mform->setType('wants', PARAM_RAW);
+
+        $mform->addElement('checkbox', 'rememberidp' , '', get_string('rememberidp', 'auth_saml2'));
 
         foreach ($metadataentities as $idpentities) {
             if (isset($idpentities[$defaultidp])) {

--- a/classes/form/selectidp_buttons.php
+++ b/classes/form/selectidp_buttons.php
@@ -53,7 +53,6 @@ class selectidp_buttons extends moodleform {
 
         $mform->addElement('hidden', 'wants', $wants);
         $mform->addElement('checkbox', 'rememberidp' , '', get_string('rememberidp', 'auth_saml2'));
-
         $mform->setType('wants', PARAM_RAW);
 
         foreach ($metadataentities as $idpentities) {

--- a/classes/form/selectidp_buttons.php
+++ b/classes/form/selectidp_buttons.php
@@ -54,6 +54,8 @@ class selectidp_buttons extends moodleform {
         $mform->addElement('hidden', 'wants', $wants);
         $mform->addElement('checkbox', 'rememberidp' , '', get_string('rememberidp', 'auth_saml2'));
 
+        $mform->setType('wants', PARAM_RAW);
+
         foreach ($metadataentities as $idpentities) {
             if (isset($idpentities[$defaultidp])) {
                 $defaultidp = $idpentities[$defaultidp];

--- a/config/authsources.php
+++ b/config/authsources.php
@@ -36,6 +36,12 @@ if (!empty($CFG->loginhttps)) {
 
 $config = [];
 
+// Grab the idp from the request if it's available
+if (isset($_GET['idp'])) {
+    $idp = $_GET['idp'];
+}
+
+// Backup in case we can't get the idp from the url param or our session idp is empty.
 // Case for specifying no $SESSION IdP, select the first configured IdP as the default.
 $metadataentities = reset($saml2auth->metadataentities);
 $idpentity = reset($metadataentities);

--- a/config/authsources.php
+++ b/config/authsources.php
@@ -37,10 +37,9 @@ if (!empty($CFG->loginhttps)) {
 $config = [];
 
 // Case for specifying no $SESSION IdP, select the first configured IdP as the default.
-$arr = array_reverse($saml2auth->metadataentities);
-$metadataentities = array_pop($arr);
-$idpentity = array_pop($metadataentities);
-$idp = md5($idpentity->entityid);
+$metadataentities = reset($saml2auth->metadataentities);
+$idpentity = reset($metadataentities);
+$idp = $idpentity->entityid;
 
 if (!empty($SESSION->saml2idp)) {
     foreach ($saml2auth->metadataentities as $idpentities) {

--- a/config/authsources.php
+++ b/config/authsources.php
@@ -37,8 +37,9 @@ if (!empty($CFG->loginhttps)) {
 $config = [];
 
 // Grab the idp from the request if it's available
-if (isset($_GET['idp'])) {
-    $idp = $_GET['idp'];
+$idpfromparam = optional_param('idp', '', PARAM_TEXT);
+if (!empty($idpfromparam)) {
+    $SESSION->saml2idp = $idpfromparam;
 }
 
 if (!empty($SESSION->saml2idp)) {

--- a/config/authsources.php
+++ b/config/authsources.php
@@ -55,7 +55,7 @@ if (!empty($SESSION->saml2idp)) {
 // Backup in case we can't get the idp from the url param or session
 // Case for specifying no $SESSION IdP, select the first configured IdP as the default.
 if (!isset($idp)) {
-    $idp = auth_saml2_get_default_idp()->entityid;
+    $idp = auth_saml2_get_fallback_idp()->entityid;
 }
 
 // The testing tool will set the IdP that it uses.

--- a/config/authsources.php
+++ b/config/authsources.php
@@ -41,12 +41,6 @@ if (isset($_GET['idp'])) {
     $idp = $_GET['idp'];
 }
 
-// Backup in case we can't get the idp from the url param or our session idp is empty.
-// Case for specifying no $SESSION IdP, select the first configured IdP as the default.
-$metadataentities = reset($saml2auth->metadataentities);
-$idpentity = reset($metadataentities);
-$idp = $idpentity->entityid;
-
 if (!empty($SESSION->saml2idp)) {
     foreach ($saml2auth->metadataentities as $idpentities) {
         foreach ($idpentities as $md5entityid => $idpentity) {
@@ -56,6 +50,12 @@ if (!empty($SESSION->saml2idp)) {
             }
         }
     }
+}
+
+// Backup in case we can't get the idp from the url param or session
+// Case for specifying no $SESSION IdP, select the first configured IdP as the default.
+if (!isset($idp)) {
+    $idp = auth_saml2_get_default_idp()->entityid;
 }
 
 // The testing tool will set the IdP that it uses.

--- a/locallib.php
+++ b/locallib.php
@@ -439,7 +439,7 @@ function auth_saml2_get_idps($active = false, $asarray = false) {
         } else {
             $idpentities[$idpentity->metadataurl][$md5entityid] = $idpentity;
         }
-        
+
     }
 
     return $idpentities;
@@ -450,7 +450,7 @@ function auth_saml2_get_idps($active = false, $asarray = false) {
  * @return object The default IdP object, or NULL if there is no default IdP set.
  */
 function auth_saml2_get_default_idp() {
-    global $DB;
+    global $DB, $saml2auth;
 
     $defaultidps = $DB->get_records('auth_saml2_idps', array('activeidp' => 1, 'defaultidp' => 1));
 
@@ -458,6 +458,18 @@ function auth_saml2_get_default_idp() {
     $defaultidp = array_shift($defaultidps);
     if ($defaultidp) {
         $defaultidp->name = empty($defaultidp->displayname) ? $defaultidp->defaultname : $defaultidp->displayname;
+    }
+
+    if (!$defaultidp
+        && isset($saml2auth->metadataentities)
+        && is_array($saml2auth->metadataentities)) {
+        // Set the default IdP to be the first in the list. Used when dual login is disabled.
+        $metadataentities = reset($saml2auth->metadataentities);
+        if (!empty($metadataentities)) {
+            $defaultidp = reset($metadataentities);
+        } else {
+            $defaultidp = null;
+        }
     }
     return $defaultidp;
 }

--- a/tests/phpunit/locallib_test.php
+++ b/tests/phpunit/locallib_test.php
@@ -444,12 +444,12 @@ class auth_saml2_locallib_testcase extends advanced_testcase {
         $this->assertFalse($auth->is_email_taken(strtoupper($user->email), $user->username));
         $this->assertFalse($auth->is_email_taken(ucfirst($user->email), $user->username));
     }
-    public function test_get_default_idp_returns_idp_object() {
+    public function test_get_fallback_idp_returns_idp_object() {
         global $DB, $saml2auth;
         $this->resetAfterTest();
         // First test when we have no idp's configured.
-        $defaultidp = auth_saml2_get_default_idp();
-        $this->assertTrue(is_null($defaultidp));
+        $fallbackidp = auth_saml2_get_fallback_idp();
+        $this->assertTrue(is_null($fallbackidp));
 
         // Add two fake IdPs.
         $metadataurl = 'https://idp.example.org/idp/shibboleth';
@@ -469,10 +469,10 @@ class auth_saml2_locallib_testcase extends advanced_testcase {
 
         // Our idps in the auth_saml2_idps table are not marked as default,
         // so we get the default idp (first in the list) from $saml2auth metadataentities
-        $defaultidp = auth_saml2_get_default_idp();
-        $this->assertTrue(is_object($defaultidp));
-        $this->assertTrue($defaultidp->entityid === 'https://idp1.example.org/idp/shibboleth');
-        $this->assertTrue($defaultidp->defaultname === 'Test IdP 1');
+        $fallbackidp = auth_saml2_get_fallback_idp();
+        $this->assertTrue(is_object($fallbackidp));
+        $this->assertTrue($fallbackidp->entityid === 'https://idp1.example.org/idp/shibboleth');
+        $this->assertTrue($fallbackidp->defaultname === 'Test IdP 1');
 
         // Update the second idp to be marked as default.
         $updatedidp = $DB->get_record('auth_saml2_idps', ['defaultname' => 'Test IdP 2']);
@@ -480,10 +480,10 @@ class auth_saml2_locallib_testcase extends advanced_testcase {
         $DB->update_record('auth_saml2_idps', $updatedidp);
 
         // Now we get the default idp object from the auth_saml2_idps table
-        $defaultidp = auth_saml2_get_default_idp();
-        $this->assertTrue(is_object($defaultidp));
-        $this->assertTrue($defaultidp->entityid === 'https://idp2.example.org/idp/shibboleth');
-        $this->assertTrue($defaultidp->defaultname === 'Test IdP 2');
+        $fallbackidp = auth_saml2_get_fallback_idp();
+        $this->assertTrue(is_object($fallbackidp));
+        $this->assertTrue($fallbackidp->entityid === 'https://idp2.example.org/idp/shibboleth');
+        $this->assertTrue($fallbackidp->defaultname === 'Test IdP 2');
     }
 }
 


### PR DESCRIPTION
For issue #338 
### An update
This has been tested and is still an issue in the latest master branch. 
To see the problem:
visit your site's saml login page
clear browser 'Cookies and other site data'
go back to your site's saml login page and log in
you will see the following error: 

> SAML2 exception: Cannot retrieve metadata for IdP 'http://adfs-test.cqu.edu.au/adfs/services/trust' because it isn't a valid IdP for this SP.

This patch resolves the issue, in that it correctly sets the IdP in a guest session.
