### PR TITLE
Add warning to admin if the site has disabled authentication plugin

### DIFF
--- a/lang/en/auth_saml2.php
+++ b/lang/en/auth_saml2.php
@@ -48,6 +48,7 @@ $string['commonname'] = 'Common Name';
 $string['countryname'] = 'Country';
 $string['debug'] = 'Debugging';
 $string['debug_help'] = '<p>This adds extra debugging to the normal moodle log | <a href=\'{$a}\'>View SSP config</a></p>';
+$string['auth_saml2disabledauthusers'] = '<p class="alert alert-warning">The ability for any auth type to use the SAML Login has been enabled, but there are users in your site linked to a disabled authentication plugin. These users may be able to login, but the Moodle session clean up task will delete their session, requiring them to login again within a short time period. Please delete these users or update the authentication used in their profile.</p>';
 $string['duallogin'] = 'Dual login';
 $string['duallogin_help'] = '
 <p>If on, then users will see both manual and a SAML login button. If off they will always be taken directly to the IdP login page.</p>


### PR DESCRIPTION
Basically when the allow any users setting is enabled, it allows any user in the system to login - even if they have a "disabled" authentication plugin in their profile.

Moodle's garbage collection of sessions deletes the sessions of users with a disabled authentication plugin - (typically every few minutes) so these users have to login to Moodle which might happen quietly behind the scenes because they are already authenticated to the IDP, but causes uncessary load on the server.

This just adds a big warning on the settings page if it detects the setting is enabled and if it can find any users in the site with a disabled auth - hopefully using record_exists is pretty quick/cheap.

@brendanheywood - this look ok to you?

The internal moodle session clean up tasks deletes sessions for users with disabled auth types.