### PR TITLE
honor moodle proxy settings (issue #161)

### DIFF
--- a/classes/admin/setting_idpmetadata.php
+++ b/classes/admin/setting_idpmetadata.php
@@ -183,6 +183,10 @@ class setting_idpmetadata extends admin_setting_configtextarea {
      * @return idp_data[]
      */
     public function get_idps_data($value) {
+        global $CFG;
+
+        require_once($CFG->libdir.'/filelib.php');
+
         $parser = new idp_parser();
         $idps = $parser->parse($value);
 
@@ -192,7 +196,7 @@ class setting_idpmetadata extends admin_setting_configtextarea {
                 continue;
             }
 
-            $rawxml = @file_get_contents($idp->idpurl);
+            $rawxml = \download_file_content($idp->idpurl);
             if ($rawxml === false) {
                 throw new setting_idpmetadata_exception(
                     get_string('idpmetadata_badurl', 'auth_saml2', $idp->idpurl)

--- a/tests/phpunit/setting_idpmetadata_test.php
+++ b/tests/phpunit/setting_idpmetadata_test.php
@@ -134,6 +134,7 @@ class setting_idpmetadata_test extends advanced_testcase {
 
     public function test_it_returns_error_if_metadata_url_is_not_valid() {
         $error = self::$config->validate('http://invalid.url.metadata.test');
+        self::assertDebuggingCalled();
         self::assertContains('Invalid metadata', $error);
         self::assertContains('http://invalid.url.metadata.test', $error);
     }


### PR DESCRIPTION
Behind a http proxy, it should fix network issue with \auth_saml2\task\metadata_refresh task and when an administrator edits idp metadata settings. #161