### PR TITLE
Trigger user_update which other plugins could use

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -689,9 +689,10 @@ class auth_plugin_saml2 extends auth_plugin_base {
                 // If set to true - don't update based on data from this call.
                 unset($user->description);
             }
-            user_update_user($user, false, false);
             // Save custom profile fields.
             profile_save_data($user);
+            // Save user and trigger event "user_updated"
+            user_update_user($user, false);
         }
 
         return $update;


### PR DESCRIPTION
I think we should trigger user_update event because we update user data. It can be important for other plugins which use user's data/
I'm using https://github.com/catalyst/moodle-local_cohortauto to put users in cohorts automatically and it must change cohorts immediately after update.
We should update user after profile because profile it is a part of user's data and it is very strange to trigger event before profile update.