### PR TITLE
Auto login / isPassive support improvements

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -49,6 +49,8 @@ class auth_plugin_saml2 extends auth_plugin_base {
         'metadataentities'   => '',
         'debug'              => 0,
         'duallogin'          => saml2_settings::OPTION_DUAL_LOGIN_YES,
+        'autologin'          => saml2_settings::OPTION_AUTO_LOGIN_NO,
+        'autologincookie'    => '',
         'anyauth'            => 1,
         'idpattr'            => 'uid',
         'mdlattr'            => 'username',

--- a/autologin.php
+++ b/autologin.php
@@ -1,0 +1,34 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Page that gets redirected to after autologin is successful.
+ *
+ * @package   auth_saml2
+ * @copyright 2020 The Open University
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../config.php');
+
+$url = required_param('url', PARAM_LOCALURL);
+$success = required_param('success', PARAM_INT);
+
+// If the login is OK (or failed expectedly), then redirect back to the destination.
+\auth_saml2\auto_login::finish((bool)$success, new moodle_url($url));
+
+// Something strange went wrong, or somebody tried to directly link here.
+print_error('errorinvalidautologin', 'auth_saml2');

--- a/classes/admin/saml2_settings.php
+++ b/classes/admin/saml2_settings.php
@@ -46,4 +46,9 @@ abstract class saml2_settings {
 
     const OPTION_FLAGGED_LOGIN_REDIRECT = 2;
 
+    const OPTION_AUTO_LOGIN_NO = 0;
+
+    const OPTION_AUTO_LOGIN_SESSION = 1;
+
+    const OPTION_AUTO_LOGIN_COOKIE = 2;
 }

--- a/classes/auto_login.php
+++ b/classes/auto_login.php
@@ -1,0 +1,226 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Auto-login class.
+ *
+ * @package   auth_saml2
+ * @copyright 2020 The Open University
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace auth_saml2;
+
+use auth_saml2\admin\saml2_settings;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Auto-login class.
+ */
+class auto_login {
+    /** @var bool True if already considered auto-login on this page. */
+    protected static $processed;
+
+    /**
+     * Called on every page to give an opportunity to auto-login.
+     *
+     * This is called on most pages via the after_require_login callback, and also by the
+     * before_http_headers callback, so it might be called twice. We only want to run it once.
+     *
+     * The auto-login system is only useful on pages which do not already require a proper login.
+     * (For example the user might be trying to access the site homepage, or a course page which
+     * allows guest access.) In this case, the auto-login system lets us attempt to log in if
+     * we think the user might be logged into the SAML identity provider, so that they automatically
+     * get access to the extra controls that may appear on that page if they are logged in to their
+     * own account.
+     */
+    public static function process() {
+        global $SESSION, $SCRIPT;
+
+        if (self::$processed) {
+            return;
+        }
+        self::$processed = true;
+
+        // Do not apply this code in auth or login scripts, because those are likely to be already
+        // handling login (either auto-login or not). Users do not need to start auto-login from
+        // these pages, only from 'normal' Moodle pages they are trying to access.
+        if (preg_match('~^(/auth/|/login/)~', $SCRIPT)) {
+            return;
+        }
+
+        // If this is not a GET request, don't try autologin.
+        if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+            return;
+        }
+
+        // Only do anything if the user isn't already logged in, and the auth plugin is enabled.
+        if (!self::check_not_logged_in_and_enabled()) {
+            return;
+        }
+
+        // Get config.
+        $auth = get_auth_plugin('saml2');
+        switch ($auth->config->autologin) {
+            // Turned off.
+            case saml2_settings::OPTION_AUTO_LOGIN_NO:
+                return;
+
+            // Login once per session. Don't try login if we already tried this session.
+            case saml2_settings::OPTION_AUTO_LOGIN_SESSION:
+                if (!empty($SESSION->auth_saml2_triedautologin)) {
+                    return;
+                }
+                break;
+
+            // Login when a cookie exists or changes. Don't try login if we already tried for this
+            // cookie value, or the cookie isn't set.
+            case saml2_settings::OPTION_AUTO_LOGIN_COOKIE:
+                // If the cookie setting isn't filled in, do nothing.
+                if (empty($auth->config->autologincookie)) {
+                    return;
+                }
+                // If the cookie isn't set, do nothing.
+                if (empty($_COOKIE[$auth->config->autologincookie])) {
+                    return;
+                }
+                // If the cookie is set to the same value it was last time we looked, do nothing.
+                $currentcookie = $_COOKIE[$auth->config->autologincookie];
+                if (!empty($SESSION->auth_saml2_lastautologincookie) &&
+                        $SESSION->auth_saml2_lastautologincookie === $currentcookie) {
+                    return;
+                }
+                break;
+        }
+
+        // Check the plugin is configured (it probably is since they set up the autologin option).
+        // Note: This check is after the switch because it's highly likely that we will exit there.
+        // is_configured is not a costly function call but it does make some filesystem checks.
+        if (!$auth->is_configured()) {
+            return;
+        }
+
+        // Record in session that we attempted login.
+        switch ($auth->config->autologin) {
+            case saml2_settings::OPTION_AUTO_LOGIN_SESSION:
+                $SESSION->auth_saml2_triedautologin = true;
+                break;
+
+            case saml2_settings::OPTION_AUTO_LOGIN_COOKIE:
+                $SESSION->auth_saml2_lastautologincookie = $currentcookie;
+                break;
+        }
+        $SESSION->auth_saml2_autologinattempt = true;
+
+        // Now actually try to log in!
+        self::login($auth);
+    }
+
+    /**
+     * Confirms that the user is not logged in, and that auth_saml2 is enabled.
+     *
+     * @return bool True if the user is not logged in (or is guest), and saml2 is enabled
+     */
+    protected static function check_not_logged_in_and_enabled() {
+        // If they are already logged in, we don't need autologin.
+        if (isloggedin() && !isguestuser()) {
+            return false;
+        }
+
+        // Check if this plugin is enabled.
+        $enabled = get_enabled_auth_plugins();
+        return in_array('saml2', $enabled);
+    }
+
+    /**
+     * Tries to auto-login by making a passive login request.
+     *
+     * Also called once redirected back after a successful request.
+     *
+     * @param \auth_plugin_saml2 $auth Auth plugin
+     */
+    protected static function login(\auth_plugin_saml2 $auth) {
+        global $CFG, $FULLME, $SESSION, $saml2auth;
+
+        require(__DIR__ . '/../setup.php');
+        $auth = get_auth_plugin('saml2');
+
+        // Set the default IdP to be the first in the list. Used when dual login is disabled.
+        $arr = array_reverse($saml2auth->metadataentities);
+        $metadataentities = array_pop($arr);
+        $idpentity = array_pop($metadataentities);
+        $idp = md5($idpentity->entityid);
+        $SESSION->saml2idp = $idp;
+
+        $simplesaml = new \SimpleSAML\Auth\Simple($auth->spname);
+
+        $params = [
+            'isPassive' => true,
+            'ErrorURL' => $CFG->wwwroot . '/auth/saml2/autologin.php?success=0&url=' .
+                    urlencode((new \moodle_url($FULLME))->out_as_local_url(false)),
+            'ReturnTo' => $CFG->wwwroot . '/auth/saml2/autologin.php?success=1&url=' .
+                urlencode((new \moodle_url($FULLME))->out_as_local_url(false))
+        ];
+
+        $simplesaml->requireAuth($params);
+
+        // We only get back here if they already logged in.
+        $attributes = $simplesaml->getAttributes();
+        $auth->saml_login_complete($attributes);
+    }
+
+    /**
+     * Finishes the login (called from autologin.php).
+     *
+     * This function redirects if successful.
+     *
+     * @param bool $success True if successful login
+     * @param \moodle_url $url URL for redirecting to
+     */
+    public static function finish($success, \moodle_url $url) {
+        global $SESSION;
+        if (empty($SESSION->auth_saml2_autologinattempt)) {
+            return;
+        }
+        unset($SESSION->auth_saml2_autologinattempt);
+
+        // Only do anything if the user isn't already logged in, and the auth plugin is enabled.
+        if (!self::check_not_logged_in_and_enabled()) {
+            return;
+        }
+
+        // Get config.
+        $auth = get_auth_plugin('saml2');
+        if ($auth->config->autologin == saml2_settings::OPTION_AUTO_LOGIN_NO) {
+            return;
+        }
+
+        // Check plugin.
+        if (!$auth->is_configured()) {
+            return;
+        }
+
+        // Now actually try to finish the login, only if it was successful!
+        if ($success) {
+            $SESSION->wantsurl = $url;
+            self::login($auth);
+        }
+
+        // If it didn't succeed, redirect.
+        redirect($url);
+    }
+}

--- a/lang/en/auth_saml2.php
+++ b/lang/en/auth_saml2.php
@@ -33,6 +33,12 @@ $string['auth_saml2description'] = 'Authenticate with a SAML2 IdP';
 $string['auth_saml2blockredirectdescription'] = 'Redirect or display message to SAML2 logins based on configured group restrictions';
 $string['autocreate'] = 'Auto create users';
 $string['autocreate_help'] = 'If users are in the IdP but not in moodle create a moodle account.';
+$string['autologin'] = 'Auto-login';
+$string['autologin_help'] = 'On pages that allow guest access without login, automatically log users into Moodle with a real user account if they are logged in to the IdP (using passive authentication).';
+$string['autologinbysession'] = 'Check once per session';
+$string['autologinbycookie'] = 'Check when the specified cookie exists or changes';
+$string['autologincookie'] = 'Auto-login cookie';
+$string['autologincookie_help'] = 'Name of cookie used to decide when to attempt auto-login (only relevant if the cookie option is selected above).';
 $string['availableidps'] = 'Select available IdPs';
 $string['availableidps_help'] = 'If an IdP metadata xml contains multiple IdP entities, you will need to select which entities are availiable
 for users to login with.';
@@ -62,6 +68,7 @@ $string['duallogin_help'] = '
 <p>If on, then external pages can deep link into moodle using saml eg /course/view.php?id=45&saml=on</p>';
 $string['emailtaken'] = 'Can\'t create a new account, because {$a} email address is already registered';
 $string['emailtakenupdate'] = 'Your email wasn\'t updated, because email address {$a} is already registered';
+$string['errorinvalidautologin'] = 'Invalid autologin request';
 $string['errorparsingxml'] = 'Error parsing XML: {$a}';
 $string['exception'] = 'SAML2 exception: {$a}';
 $string['expirydays'] = 'Expiry in Days';

--- a/lib.php
+++ b/lib.php
@@ -20,6 +20,8 @@
  * @copyright Catalyst IT
  */
 
+defined('MOODLE_INTERNAL') || die();
+
 /**
  * Check if we have the saml=on param set. If so, disable guest access and force the user to log in with saml.
  *
@@ -44,4 +46,21 @@ function auth_saml2_after_config() {
         error_log('auth_saml2_afer_config error! ' . $exception->getTraceAsString());
         // @codingStandardsIgnoreEnd
     }
+}
+
+/**
+ * Callback immediately after require_login succeeds.
+ *
+ * This callback requires Moodle 3.7+. On earlier versions this will not run. It also won't run
+ * on pages which don't call require_login, so we use the _before_http_headers() callback too.
+ */
+function auth_saml2_after_require_login() {
+    \auth_saml2\auto_login::process();
+}
+
+/**
+ * Callback before HTTP headers are sent.
+ */
+function auth_saml2_before_http_headers() {
+    \auth_saml2\auto_login::process();
 }

--- a/settings.php
+++ b/settings.php
@@ -187,6 +187,24 @@ if ($ADMIN->fulltree) {
             saml2_settings::OPTION_DUAL_LOGIN_YES,
             $dualloginoptions));
 
+    // Auto login.
+    $autologinoptions = [
+        saml2_settings::OPTION_AUTO_LOGIN_NO => get_string('no'),
+        saml2_settings::OPTION_AUTO_LOGIN_SESSION => get_string('autologinbysession', 'auth_saml2'),
+        saml2_settings::OPTION_AUTO_LOGIN_COOKIE => get_string('autologinbycookie', 'auth_saml2'),
+    ];
+    $settings->add(new admin_setting_configselect(
+            'auth_saml2/autologin',
+            get_string('autologin', 'auth_saml2'),
+            get_string('autologin_help', 'auth_saml2'),
+            saml2_settings::OPTION_AUTO_LOGIN_NO,
+            $autologinoptions));
+    $settings->add(new admin_setting_configtext(
+            'auth_saml2/autologincookie',
+            get_string('autologincookie', 'auth_saml2'),
+            get_string('autologincookie_help', 'auth_saml2'),
+            '', PARAM_TEXT));
+
     // Allow any auth type.
     $settings->add(new admin_setting_configselect(
             'auth_saml2/anyauth',

--- a/tests/behat/autologin.feature
+++ b/tests/behat/autologin.feature
@@ -1,0 +1,150 @@
+@auth @auth_saml2 @javascript
+Feature: Automatically log in
+  In order to have correct Moodle access on pages that allow public access
+  As a user
+  I should be automatically logged in if I am logged into the IdP
+
+  Scenario: Autologin on first request in session (logged in)
+    Given the authentication plugin saml2 is enabled # auth_saml2
+    And the mock SAML IdP is configured # auth_saml2
+    And the following "users" exist:
+      | username | auth  | firstname | lastname |
+      | student1 | saml2 | Eigh      | Person   |
+    And the following "courses" exist:
+      | shortname | fullname |
+      | C1        | Course 1 |
+    And the following "course enrolments" exist:
+      | user     | course | role |
+      | student1 | C1     | student |
+    And the following config values are set as admin:
+      | auth      | saml2 |            |
+      | autologin | 1     | auth_saml2 |
+    When I am on site homepage
+    And the mock SAML IdP allows passive login with the following attributes: # auth_saml2
+      | uid | student1 |
+    Then I should see "Course 1"
+    And I should see "Eigh Person" in the ".userbutton" "css_element"
+
+    # Future requests should not contact the IdP (obviously, because logged in).
+    When I follow "Course 1"
+    Then I should see "Course 1"
+    And I should see "Participants"
+
+  Scenario: Autologin on first request in session (not logged in)
+    Given the authentication plugin saml2 is enabled # auth_saml2
+    And the mock SAML IdP is configured # auth_saml2
+    And the following "courses" exist:
+      | shortname | fullname |
+      | C1        | Course 1 |
+    And the following config values are set as admin:
+      | auth      | saml2 |            |
+      | autologin | 1     | auth_saml2 |
+    When I am on site homepage
+    And the mock SAML IdP does not allow passive login # auth_saml2
+    Then I should see "You are not logged in."
+
+    # Future requests should not contact the IdP.
+    When I follow "Course 1"
+    Then I should see "Forgotten your username or password?"
+
+  Scenario: Autologin on cookie change
+    Given the authentication plugin saml2 is enabled # auth_saml2
+    And the mock SAML IdP is configured # auth_saml2
+    And the following "users" exist:
+      | username | auth  | firstname | lastname |
+      | student1 | saml2 | Eigh      | Person   |
+    And the following "courses" exist:
+      | shortname | fullname |
+      | C1        | Course 1 |
+    And the following "course enrolments" exist:
+      | user     | course | role |
+      | student1 | C1     | student |
+    And the following config values are set as admin:
+      | auth            | saml2 |            |
+      | autologin       | 2     | auth_saml2 |
+      | autologincookie | frog  | auth_saml2 |
+
+    # No login attempt initially.
+    When I am on site homepage
+    Then I should see "You are not logged in."
+
+    # Changing the cookies results in a login attempt.
+    When the cookie "frog" is set to "Kermit" # auth_saml2
+    And I am on site homepage
+    And the mock SAML IdP does not allow passive login # auth_saml2
+    Then I should see "You are not logged in."
+
+    # No login attempt on another page request.
+    When I am on site homepage
+    Then I should see "You are not logged in."
+
+    # Changing cookies again, there will be another login attempt.
+    When the cookie "frog" is set to "Mr Toad" # auth_saml2
+    And I am on site homepage
+    And the mock SAML IdP allows passive login with the following attributes: # auth_saml2
+      | uid | student1 |
+    Then I should see "Eigh Person" in the ".userbutton" "css_element"
+
+    # No login attempt on another page request, even if the cookie changes
+    # or is removed, because the user is logged in now.
+    When the cookie "frog" is set to "Kermit" # auth_saml2
+    And I am on site homepage
+    Then I should see "Eigh Person" in the ".userbutton" "css_element"
+    When the cookie "frog" is removed # auth_saml2
+    And I am on site homepage
+    Then I should see "Eigh Person" in the ".userbutton" "css_element"
+
+  Scenario: Situations which are excluded from autologin
+    Given the authentication plugin saml2 is enabled # auth_saml2
+    And the mock SAML IdP is configured # auth_saml2
+    And the following "users" exist:
+      | username | auth  | firstname | lastname |
+      | student1 | saml2 | Eigh      | Person   |
+    And the following config values are set as admin:
+      | auth            | saml2 |            |
+      | autologin       | 2     | auth_saml2 |
+      | autologincookie | frog  | auth_saml2 |
+    And I am on site homepage
+
+    # With this config, changing the cookie would usually result in an autologin attempt.
+    When the cookie "frog" is set to "Kermit" # auth_saml2
+
+    # Situation 1: Autologin does not run on login screens.
+    And I follow "Log in"
+    Then I should see "You are not logged in."
+
+    # Situation 2: Autologin does not run if turned off (obviously).
+    When the following config values are set as admin:
+      | autologin | 0 | auth_saml2 |
+    And I am on site homepage
+    Then I should see "You are not logged in."
+
+    # Situation 3: Autologin does not run if the plugin is not enabled.
+    When the following config values are set as admin:
+      | autologin | 2      | auth_saml2 |
+      | auth      | manual |            |
+    And I am on site homepage
+    Then I should see "You are not logged in."
+
+    # Set up the homepage so that we can test POST requests
+    When I log in as "admin"
+    And I follow "Site home"
+    And I navigate to "Edit settings" in current page administration
+    And I set the field "summary" to "<form method='post' action='.'><div><button type='submit'>PostTest</button></div></form>"
+    And I press "Save changes"
+    And I follow "Site home"
+    And I navigate to "Turn editing on" in current page administration
+    And I add the "Course/site summary" block
+    And I log out
+
+    # Situation 4: Autologin does not run on POST requests.
+    When the following config values are set as admin:
+      | auth | saml2 |
+    And I press "PostTest"
+    Then I should see "You are not logged in."
+
+    # Finally, just confirm we have things set up right by trying a normal GET request.
+    When I am on site homepage
+    And the mock SAML IdP allows passive login with the following attributes: # auth_saml2
+      | uid | student1 |
+    Then I should see "Eigh Person"

--- a/tests/behat/behat_auth_saml2.php
+++ b/tests/behat/behat_auth_saml2.php
@@ -333,6 +333,35 @@ EOF;
         $this->getSession()->getDriver()->click('//button');
     }
 
+    /**
+     * Sets a cookie (for use testing the autologin based on cookie).
+     *
+     * @When /^the cookie "([^"]+)" is set to "([^"]+)" +\# auth_saml2$/
+     */
+    public function the_cookie_is_set_to($cookiename, $value) {
+        $this->getSession()->getDriver()->executeScript('document.cookie = "' .
+                addslashes_js($cookiename) . '=' . addslashes_js($value) . '";');
+    }
+
+    /**
+     * Clears a cookie (for use testing the autologin based on cookie).
+     *
+     * @When /^the cookie "([^"]+)" is removed +\# auth_saml2$/
+     */
+    public function the_cookie_is_removed($cookiename) {
+        $this->getSession()->getDriver()->executeScript('document.cookie = "' .
+                addslashes_js($cookiename) . '=; expires=Thu, 01 Jan 1970 00:00:00 GMT";');
+    }
+
+    private function visit_saml2_login_page() {
+        $this->getSession()->visit($this->locate_path('http://simplesamlphp.test:8001/module.php/core/authenticate.php'));
+    }
+
+    private function reset_saml2_session() {
+        $this->visit_saml2_login_page();
+        $this->getSession()->reset();
+    }
+
     private function reset_moodle_session() {
         $this->iGoToTheLoginPageWithAuth_saml('saml=off');
         $this->getSession()->reset();

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021011500;    // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2021011500;    // Match release exactly to version.
+$plugin->version   = 2021040100;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2021040100;    // Match release exactly to version.
 $plugin->requires  = 2017051509;    // Requires PHP 7, 2017051509 = T12. M3.3
                                     // Strictly we require either Moodle 3.5 OR
                                     // we require Totara 3.3, but the version number


### PR DESCRIPTION
**Note**: This pull request currently includes 2 commits but the first commit is just my other pull request about making Behat testing easier https://github.com/catalyst/moodle-auth_saml2/pull/419. 

This feature is a new configuration option that allows users to configure auth_saml2 to attempt passive login automatically, without the user having to go to a login page.

This is useful for servers that allow users to access without being logged in (e.g. public access), but where some users might be already logged on to the institutional identity provider.

There are two options: try at the start of a session, or try every time a cookie changes. The first option is simple but means it won't detect login if you go to the server before logging in. The second option can be useful if you are able to configure your identity provider to set a cookie, within the domain used by the Moodle system, when the user logs in.

In both cases, it will not do anything when you are already logged in (this is an autologin feature, not autologout).