### PR TITLE
Match simplesaml session.duration to Moodle sessiontimeout

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -59,7 +59,7 @@ $config = array(
     // TODO \core_user::get_support_user().
     'timezone' => class_exists('core_date') ? core_date::get_server_timezone() : null,
 
-    'session.duration'          => 60 * 60 * 8, // 8 hours. TODO same as moodle.
+    'session.duration'          => (int)$CFG->sessiontimeout,
     'session.datastore.timeout' => 60 * 60 * 4,
     'session.state.timeout'     => 60 * 60,
 


### PR DESCRIPTION
The session duration for simplesamlphp was set to 8hrs so if you set the Moodle session timeout to 1 hour you were re-authenticated by auth_saml2 without having been sent to the IDP.
The use case for me was:
Client sets IDP timeout to 1hr, Moodle session timeout too 15min. After 1hr and 1min of inactivity the Moodle session is silently renewed without the user hitting the IDP and being forced to re-authenticate.