### PR TITLE
Redirect guest continue button for self enrolment

### DIFF
--- a/classes/auth.php
+++ b/classes/auth.php
@@ -410,10 +410,16 @@ class auth extends \auth_plugin_base {
             $saml = 0;
         }
 
-        // Never redirect on POST.
+        // Sometimes redirect on POST to catch guest "continue" button in self enrolment.
         if (isset($_SERVER['REQUEST_METHOD']) && ($_SERVER['REQUEST_METHOD'] == 'POST')) {
-            $this->log(__FUNCTION__ . ' skipping due to method=post');
-            return false;
+            if (empty($_POST['username']) && empty($_POST['password'])) {
+                $this->log(__FUNCTION__ . ' redirecting due to missing username and password in POST (guest)');
+                $loginurl = new moodle_url('/auth/saml2/login.php');
+                redirect($loginurl);
+            } else {
+                $this->log(__FUNCTION__ . ' skipping due to method=post');
+                return false;
+            }
         }
 
         // Never redirect if requested so.


### PR DESCRIPTION
Setup:

auth_saml2 : duallogin = no

http://moodle.local/enrol/index.php?id=2


If you have Guest access enabled and a course with allow self enrolment, Moodle displays a button that says "Continue" which performs a POST with no variables to /login/index.php

If the site is using auth_saml2 then the user gets stuck on the /login/index.php page with no way to login via saml.

This PR catches the empty post and redirects to the saml login page, fixing the guest self enrolment continue button.