### PR TITLE
Allowing PHP Unit to work in version 8 and above

### DIFF
--- a/tests/phpunit/metadata_refresh_test.php
+++ b/tests/phpunit/metadata_refresh_test.php
@@ -36,7 +36,7 @@ defined('MOODLE_INTERNAL') || die();
  */
 class auth_saml2_metadata_refresh_testcase extends advanced_testcase {
 
-    public function setUp() {
+    public function setUp():void {
         $this->resetAfterTest(true);
     }
 

--- a/tests/phpunit/redis_store_test.php
+++ b/tests/phpunit/redis_store_test.php
@@ -40,7 +40,7 @@ class auth_saml2_redis_store_testcase extends advanced_testcase {
      */
     protected $redis;
 
-    public function setUp() {
+    public function setUp():void {
         if (!$this->is_redis_available()) {
             $this->markTestSkipped('Redis was not available - skipping test');
         }
@@ -51,7 +51,7 @@ class auth_saml2_redis_store_testcase extends advanced_testcase {
         $this->redis->setOption(\Redis::OPT_SERIALIZER, \Redis::SERIALIZER_PHP);
     }
 
-    public function tearDown() {
+    public function tearDown():void {
         unset($this->redis);
     }
 

--- a/tests/phpunit/setting_idpmetadata_test.php
+++ b/tests/phpunit/setting_idpmetadata_test.php
@@ -32,7 +32,7 @@ class setting_idpmetadata_test extends advanced_testcase {
     /** @var setting_idpmetadata */
     private static $config;
 
-    protected function setUp() {
+    protected function setUp():void {
         parent::setUp();
         self::$config = new setting_idpmetadata();
     }
@@ -154,7 +154,7 @@ class setting_idpmetadata_test extends advanced_testcase {
      * @static
      * @return void
      */
-    public static function tearDownAfterClass() {  // @codingStandardsIgnoreLine - ignore case of function.
+    public static function tearDownAfterClass():void {  // @codingStandardsIgnoreLine - ignore case of function.
         parent::tearDownAfterClass();
         if (self::$config) {
             self::$config = null;


### PR DESCRIPTION
Adding :void to stop PHP Unit tests in other plugins not fail because of missing :void in this

