### PR TITLE
Add initial github actions config for 3.5, 3.8-> master, php 7.2, 7.4

### DIFF
--- a/.github/workflows/35.yml
+++ b/.github/workflows/35.yml
@@ -1,0 +1,123 @@
+name: Moodle plugin CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+# Run this workflow every time a new commit pushed to your repository
+
+on: push
+
+jobs:
+  citest:
+    name: CI test
+    runs-on: 'ubuntu-latest'
+
+    services:
+      postgres:
+        image: postgres:9.5
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+        ports:
+          - 5432:5432
+
+      mariadb:
+        image: mariadb:10
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+    strategy:
+      fail-fast: false
+      matrix:
+        database: ['pgsql', 'mariadb']
+        moodle-branch: ['MOODLE_35_STABLE']
+        node: ['14.15.1']
+        php: ['7.0', '7.2']
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          path: plugin
+
+      - name: Install node  ${{ matrix.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: pgsql, mysqli, zip, gd, xmlrpc, soap
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          # Add dirs to $PATH
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          # PHPUnit depends on en_AU.UTF-8 locale
+          sudo locale-gen en_AU.UTF-8
+      - name: Install Moodle
+        run: |
+          mkdir ~/.npm-global
+          npm config set prefix '~/.npm-global'
+          export PATH=~/.npm-global/bin:$PATH
+          source ~/.profile
+          moodle-plugin-ci install -vvv --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: Run phplint
+        if: ${{ always() }}
+        run: moodle-plugin-ci phplint
+
+      - name: Run phpcpd
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpcpd || true
+
+      - name: Run phpmd
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: Run codechecker
+        if: ${{ always() }}
+        run: moodle-plugin-ci codechecker
+
+      - name: Run validate
+        if: ${{ always() }}
+        run: moodle-plugin-ci validate
+
+      - name: Run savepoints
+        if: ${{ always() }}
+        run: moodle-plugin-ci savepoints
+
+      - name: Run mustache
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpcpd
+
+      - name: Run grunt
+        if: ${{ always() }}
+        run: moodle-plugin-ci grunt
+
+      - name: Run phpunit
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit
+
+      - name: Run behat
+        if: ${{ always() }}
+        run: moodle-plugin-ci behat --profile chrome 

--- a/.github/workflows/38-master.yml
+++ b/.github/workflows/38-master.yml
@@ -1,0 +1,123 @@
+name: Moodle plugin CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+# Run this workflow every time a new commit pushed to your repository
+
+on: push
+
+jobs:
+  citest:
+    name: CI test
+    runs-on: 'ubuntu-latest'
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+        ports:
+          - 5432:5432
+
+      mariadb:
+        image: mariadb
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+    strategy:
+      fail-fast: false
+      matrix:
+        database: ['pgsql', 'mariadb']
+        moodle-branch: ['MOODLE_38_STABLE','MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE', 'master']
+        node: ['14.15.1']
+        php: ['7.2', '7.4']
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          path: plugin
+
+      - name: Install node  ${{ matrix.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: pgsql, zip, gd, xmlrpc, soap
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          # Add dirs to $PATH
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          # PHPUnit depends on en_AU.UTF-8 locale
+          sudo locale-gen en_AU.UTF-8
+      - name: Install Moodle
+        run: |
+          mkdir ~/.npm-global
+          npm config set prefix '~/.npm-global'
+          export PATH=~/.npm-global/bin:$PATH
+          source ~/.profile
+          moodle-plugin-ci install -vvv --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: Run phplint
+        if: ${{ always() }}
+        run: moodle-plugin-ci phplint
+
+      - name: Run phpcpd
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpcpd || true
+
+      - name: Run phpmd
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: Run codechecker
+        if: ${{ always() }}
+        run: moodle-plugin-ci codechecker
+
+      - name: Run validate
+        if: ${{ always() }}
+        run: moodle-plugin-ci validate
+
+      - name: Run savepoints
+        if: ${{ always() }}
+        run: moodle-plugin-ci savepoints
+
+      - name: Run mustache
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpcpd
+
+      - name: Run grunt
+        if: ${{ always() }}
+        run: moodle-plugin-ci grunt
+
+      - name: Run phpunit
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit
+
+      - name: Run behat
+        if: ${{ always() }}
+        run: moodle-plugin-ci behat --profile chrome 


### PR DESCRIPTION
this is pretty close to replicating the existing travis config.

The actions are failing on php 7.2 / 7.4 branches but there are separate pull requests incoming to fix these.

I haven't deleted the travis config in this yet as it might be handy to run them side-by-side for a little while.