### PR TITLE
setup/setuplib.php are internal files - not called directly.

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -22,11 +22,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+defined('MOODLE_INTERNAL') || die();
+
 use auth_saml2\event\cert_regenerated;
 
-// @codingStandardsIgnoreStart
-require_once(__DIR__ . '/../../config.php');
-// @codingStandardsIgnoreEnd
 require_once(__DIR__ . '/setuplib.php');
 
 global $CFG, $saml2auth;

--- a/setuplib.php
+++ b/setuplib.php
@@ -22,11 +22,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+defined('MOODLE_INTERNAL') || die();
+
 use auth_saml2\ssl_algorithms;
 
-// @codingStandardsIgnoreStart
-require_once(__DIR__ . '/../../config.php');
-// @codingStandardsIgnoreEnd
 require_once(__DIR__ . '/_autoload.php');
 
 global $CFG;


### PR DESCRIPTION
fixes #489 in a less funky way.

setuplib.php has no business including config.php, and setup.php seems to be only used by require('setup.php') calls within other scripts so as an internal file it shouldn't either.

This causes issues with Totara 13 (more detail in issue #489) but these files are not really designed to be called via http so should use the internal checks as included.