### PR TITLE
Include moodle config file in metadata

### DIFF
--- a/sp/metadata.php
+++ b/sp/metadata.php
@@ -28,6 +28,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+require_once('../../../config.php');
 require_once('../setup.php');
 require_once('../locallib.php');
 


### PR DESCRIPTION
https://github.com/catalyst/moodle-auth_saml2/blob/master/setup.php#L25 setup.php is now a moodle internal file,  https://github.com/catalyst/moodle-auth_saml2/blob/master/sp/metadata.php#L31 calls setup.php without including config.php causing setup.php to die.