### PR TITLE
513 add password to redis

### DIFF
--- a/classes/redis_store.php
+++ b/classes/redis_store.php
@@ -110,6 +110,11 @@ class redis_store extends \SimpleSAML\Store {
         try {
             $redis = new \Redis();
             $redis->connect($CFG->auth_saml2_redis_server);
+
+            if (!empty($CFG->auth_saml2_redis_password)) {
+                $redis->auth($CFG->auth_saml2_redis_password);
+            }
+
         } catch (\RedisException $e) {
             throw new \coding_exception("RedisException caught with message: {$e->getMessage()}");
         }


### PR DESCRIPTION
From version 5.3 the password could already be transferred with redis->connect (…). But since not all instances use v5.3 or higher, the idea is to transfer the password later with redis->auth(...).
Another CFG variable auth_saml2_redis_password is introduced for this purpose. Authentication with a password is only possible if this is also set in config.php.

For more information see: https://github.com/phpredis/phpredis#connect-open