### PR TITLE
Fix CI runs

### DIFF
--- a/.github/workflows/35.yml
+++ b/.github/workflows/35.yml
@@ -74,7 +74,6 @@ jobs:
       - name: Install Moodle
         run: |
           mkdir ~/.npm-global
-          npm config set prefix '~/.npm-global'
           export PATH=~/.npm-global/bin:$PATH
           source ~/.profile
           moodle-plugin-ci install -vvv --plugin ./plugin --db-host=127.0.0.1

--- a/.github/workflows/38-master.yml
+++ b/.github/workflows/38-master.yml
@@ -44,6 +44,11 @@ jobs:
         moodle-branch: ['MOODLE_38_STABLE','MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE', 'master']
         node: ['14.15.1']
         php: ['7.2', '7.4']
+        exclude:
+          - moodle-branch: master
+            php: 7.2
+          - moodle-branch: MOODLE_311_STABLE
+            php: 7.2
 
     steps:
       - name: Check out repository code
@@ -74,7 +79,6 @@ jobs:
       - name: Install Moodle
         run: |
           mkdir ~/.npm-global
-          npm config set prefix '~/.npm-global'
           export PATH=~/.npm-global/bin:$PATH
           source ~/.profile
           moodle-plugin-ci install -vvv --plugin ./plugin --db-host=127.0.0.1


### PR DESCRIPTION
The GitHub Actions CI runs are all failing at the moment. I've made a couple of changes which make it pass on master branch:

- Removed npm set prefix, which broke everything
- Removed PHP 7.2 for master and MOODLE_311_STABLE (these branches require PHP 7.3+)