### PR TITLE
Removing references to the now unsupported loginhttps

### DIFF
--- a/config/authsources.php
+++ b/config/authsources.php
@@ -28,12 +28,6 @@ defined('MOODLE_INTERNAL') || die();
 
 global $saml2auth, $CFG, $SITE, $SESSION;
 
-// Check for https login.
-$wwwroot = $CFG->wwwroot;
-if (!empty($CFG->loginhttps)) {
-    $wwwroot = str_replace('http:', 'https:', $CFG->wwwroot);
-}
-
 $config = [];
 
 // Case for specifying no $SESSION IdP, select the first configured IdP as the default.
@@ -57,7 +51,7 @@ if (!empty($SESSION->saml2idp)) {
 
 $config[$saml2auth->spname] = [
     'saml:SP',
-    'entityID' => "$wwwroot/auth/saml2/sp/metadata.php",
+    'entityID' => "$CFG->wwwroot/auth/saml2/sp/metadata.php",
     'discoURL' => !empty($CFG->auth_saml2_disco_url) ? $CFG->auth_saml2_disco_url : null,
     'idp' => empty($CFG->auth_saml2_disco_url) ? $idpentityid : null,
     'NameIDPolicy' => $saml2auth->config->nameidpolicy,

--- a/config/config.php
+++ b/config/config.php
@@ -28,12 +28,6 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG, $saml2auth, $saml2config;
 
-// Check for https login.
-$wwwroot = $CFG->wwwroot;
-if (!empty($CFG->loginhttps)) {
-    $wwwroot = str_replace('http:', 'https:', $CFG->wwwroot);
-}
-
 $metadatasources = [];
 foreach ($saml2auth->metadataentities as $metadataurl => $idpentities) {
     $metadatasources[] = [
@@ -45,9 +39,9 @@ foreach ($saml2auth->metadataentities as $metadataurl => $idpentities) {
 $remoteip = getremoteaddr();
 
 $config = array(
-    'baseurlpath'       => $wwwroot . '/auth/saml2/sp/',
+    'baseurlpath'       => $CFG->wwwroot . '/auth/saml2/sp/',
     'application'       => [
-      'baseURL'         => $wwwroot . '/auth/saml2/sp/',
+      'baseURL'         => $CFG->wwwroot . '/auth/saml2/sp/',
     ],
     'certdir'           => $saml2auth->get_saml2_directory() . '/',
     'debug'             => $saml2auth->config->debug ? true : false,


### PR DESCRIPTION
This is a potential fix for https://github.com/catalyst/moodle-auth_saml2/issues/529