### PR TITLE
Improve user search in saml_login_complete method.

### DIFF
--- a/classes/auth.php
+++ b/classes/auth.php
@@ -594,7 +594,10 @@ class auth extends \auth_plugin_base {
                 $this->log(__FUNCTION__ . " to lowercase for $key => $uid");
                 $uid = strtolower($uid);
             }
-            if ($user = $DB->get_record('user', array( $this->config->mdlattr => $uid, 'deleted' => 0 ))) {
+            if ($user = $DB->get_record('user', array(
+                    $this->config->mdlattr => $uid,
+                    'deleted' => 0,
+                    'mnethostid' => $CFG->mnet_localhost_id))) {
                 continue;
             }
         }


### PR DESCRIPTION
Add mnethostid to the search condition in order to benefit from the uniqueindex (mnethostid, username) in user table.

Recreated as #541 was closed accidentally.