### PR TITLE
Fix warnings (in log screens) when cert regenerated without user id

### DIFF
--- a/classes/event/cert_regenerated.php
+++ b/classes/event/cert_regenerated.php
@@ -43,10 +43,10 @@ class cert_regenerated extends base {
      */
     public function get_description() {
         $userregenerated = '';
-        if ($this->other['userid']) {
+        if (!empty($this->other['userid'])) {
             $userregenerated .= "'{$this->other['userid']}'";
         } else {
-            $userregenerated .= 'unkown';
+            $userregenerated .= 'unknown';
         }
         return "The saml certificates were regenerated: '{$this->other['reason']}' by user $userregenerated";
     }


### PR DESCRIPTION
On behat init (and some other cases), certificates can be regenerated
without a userid in the log entry. If that happens and anyone views
logs, it causes a warning because the array value doesn't exist.