### PR TITLE
Improve Behat check in setup to supress debug call in test env.

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -52,10 +52,10 @@ if ($missingcertpem || $missingcertcrt) {
     $missingcertpem ? $errorstring .= "= Missing cert pem file! =\n" : null;
     $missingcertcrt ? $errorstring .= "= Missing cert crt file! = \n" : null;
     $errorstring .= "Now regenerating saml2 certificates...";
-    if (!(PHPUNIT_TEST || defined('BEHAT_TEST'))) {
+    if (!(PHPUNIT_TEST || (defined('BEHAT_TEST') && BEHAT_TEST) ||
+            defined('BEHAT_SITE_RUNNING'))) {
         debugging($errorstring);
     }
-
     try {
         create_certificates($saml2auth);
     } catch (saml2_exception $exception) {


### PR DESCRIPTION
Apparently this debug message pops up on custom fields management page Behat test in the other plugin. Not shure how this gets included, but more precise check seems supress the message. 