### PR TITLE
Fix auto-login when going directly to activity

### DIFF
--- a/classes/auto_login.php
+++ b/classes/auto_login.php
@@ -153,7 +153,7 @@ class auto_login {
      * @param \auth_plugin_saml2 $auth Auth plugin
      */
     protected static function login(\auth_plugin_saml2 $auth) {
-        global $CFG, $FULLME, $SESSION, $saml2auth;
+        global $CFG, $FULLME, $SESSION, $SCRIPT, $saml2auth;
 
         require(__DIR__ . '/../setup.php');
         $auth = get_auth_plugin('saml2');
@@ -165,14 +165,22 @@ class auto_login {
         $idp = md5($idpentity->entityid);
         $SESSION->saml2idp = $idp;
 
+        // Target URL is normally the same as current page, but if we got redirected to enrol.php
+        // with a 'wants' URL, then that means if the login is successful we should try again at
+        // the original URL.
+        $target = $FULLME;
+        if ($SCRIPT === '/enrol/index.php' && !empty($SESSION->wantsurl)) {
+            $target = $SESSION->wantsurl;
+            unset($SESSION->wantsurl);
+        }
+        $encodedtarget = urlencode((new \moodle_url($target))->out_as_local_url(false));
+
         $simplesaml = new \SimpleSAML\Auth\Simple($auth->spname);
 
         $params = [
             'isPassive' => true,
-            'ErrorURL' => $CFG->wwwroot . '/auth/saml2/autologin.php?success=0&url=' .
-                    urlencode((new \moodle_url($FULLME))->out_as_local_url(false)),
-            'ReturnTo' => $CFG->wwwroot . '/auth/saml2/autologin.php?success=1&url=' .
-                urlencode((new \moodle_url($FULLME))->out_as_local_url(false))
+            'ErrorURL' => $CFG->wwwroot . '/auth/saml2/autologin.php?success=0&url=' . $encodedtarget,
+            'ReturnTo' => $CFG->wwwroot . '/auth/saml2/autologin.php?success=1&url=' . $encodedtarget
         ];
 
         $simplesaml->requireAuth($params);

--- a/tests/behat/autologin.feature
+++ b/tests/behat/autologin.feature
@@ -94,6 +94,31 @@ Feature: Automatically log in
     And I am on site homepage
     Then I should see "Eigh Person" in the ".userbutton" "css_element"
 
+  Scenario: Autologin to activity page within a course
+    Given the authentication plugin saml2 is enabled # auth_saml2
+    And the mock SAML IdP is configured # auth_saml2
+    And the following "users" exist:
+      | username | auth  | firstname | lastname |
+      | student1 | saml2 | Eigh      | Person   |
+    And the following "courses" exist:
+      | shortname | fullname |
+      | C1        | Course 1 |
+    And the following "activities" exist:
+      | activity | course | idnumber | name           | content               |
+      | page     | C1     | page1    | Test page name | Test page description |
+    And the following "course enrolments" exist:
+      | user     | course | role    |
+      | student1 | C1     | student |
+    And the following config values are set as admin:
+      | auth            | saml2 |            |
+      | autologinguests | 1     |            |
+      | autologin       | 1     | auth_saml2 |
+    When I am on the "page1" "Activity" page
+    And the mock SAML IdP allows passive login with the following attributes: # auth_saml2
+      | uid | student1 |
+    Then I should see "Test page description"
+    And I should see "Eigh Person" in the ".userbutton" "css_element"
+
   Scenario: Situations which are excluded from autologin
     Given the authentication plugin saml2 is enabled # auth_saml2
     And the mock SAML IdP is configured # auth_saml2


### PR DESCRIPTION
With Moodle autologinguest and SAML autologin both on, if you go to
an activity when you are not logged in, you get redirected to
enrol/index.php for the course before the SAML autologin feature
triggers. Autologin does happen correctly on the enrol page, but
after a successful autologin (if you now have access to the course)
you end up on the course page, not the activity page.

This change fixes that behaviour so that after successful autologin
you get to the activity page that you originally requested, using
$SESSION->wantsurl (which is set by require_login just before it
redirects you to the enrol page).

If this isn't clear, the Behat test below should clarify - at the end of the Behat scenario it tests you are on the Page by looking for the page's text. Before this change, you ended up on the course main page so the Behat would fail.