### PR TITLE
Defaultidp ambiguity fix

### DIFF
--- a/classes/form/selectidp_buttons.php
+++ b/classes/form/selectidp_buttons.php
@@ -48,7 +48,7 @@ class selectidp_buttons extends moodleform {
         $mform = $this->_form;
 
         $metadataentities = $this->_customdata['metadataentities'];
-        $defaultidp = $this->_customdata['defaultidp'];
+        $storedchoiceidp = $this->_customdata['storedchoiceidp'];
         $wants = $this->_customdata['wants'];
 
         $mform->addElement('hidden', 'wants', $wants);
@@ -56,11 +56,11 @@ class selectidp_buttons extends moodleform {
         $mform->addElement('checkbox', 'rememberidp' , '', get_string('rememberidp', 'auth_saml2'));
 
         foreach ($metadataentities as $idpentities) {
-            if (isset($idpentities[$defaultidp])) {
-                $defaultidp = $idpentities[$defaultidp];
-                $mform->addElement('html', $this->get_idpbutton($defaultidp, $defaultidp->name, $defaultidp->logo, true));
+            if (isset($idpentities[$storedchoiceidp])) {
+                $storedchoiceidp = $idpentities[$storedchoiceidp];
+                $mform->addElement('html', $this->get_idpbutton($storedchoiceidp, $storedchoiceidp->name, $storedchoiceidp->logo, true));
                 $mform->addElement('html', '<hr>');
-                unset($idpentities[$defaultidp]);
+                unset($idpentities[$storedchoiceidp]);
             }
 
             foreach ($idpentities as $idpentityid => $idp) {

--- a/selectidp.php
+++ b/selectidp.php
@@ -43,14 +43,16 @@ $PAGE->requires->css('/auth/saml2/styles.css');
 $wants = optional_param('wants', '', PARAM_RAW);
 
 $idpname = $saml2auth->config->idpname;
-$defaultidp = $saml2auth->get_idp_cookie();
+
+// Retrieve IdP used for login when 'rememberidp' checkbox was set.
+$storedchoiceidp = $saml2auth->get_idp_cookie();
 if (empty($idpname)) {
     $idpname = get_string('idpnamedefault', 'auth_saml2');
 }
 
 $data = [
     'metadataentities' => $saml2auth->metadataentities,
-    'defaultidp' => $defaultidp,
+    'storedchoiceidp' => $storedchoiceidp,
     'wants' => $wants,
     'idpname' => $idpname
 ];
@@ -81,12 +83,12 @@ if ($fromform = $mform->get_data()) {
     $loginurl = new moodle_url('/auth/saml2/login.php', $params);
     redirect($loginurl);
 } else {
-    $rememberidp = $defaultidp !== '' ? 1 : 0;
+    $rememberidp = $storedchoiceidp !== '' ? 1 : 0;
 
     $data = array('rememberidp' => $rememberidp);
 
     if ($displaytype == saml2_settings::OPTION_MULTI_IDP_DISPLAY_DROPDOWN) {
-        $data['idp'] = $defaultidp;
+        $data['idp'] = $storedchoiceidp;
     }
 
     $mform->set_data($data);
@@ -101,7 +103,7 @@ if ($fromform = $mform->get_data()) {
 
         $params = [
             'wants' => $wants,
-            'idp' => $defaultidp,
+            'idp' => $storedchoiceidp,
             'passive' => 1,
             'errorurl' => $errorurl->out(false)
         ];


### PR DESCRIPTION
This issue I spotted when working on auth constructor chanages (PR to follow), basically `$defaultidp` in the context of `selectidp.php` and its form is not what is called default IdP in the context of `auth` class, this is a choice when "remember selection" checkbox is ticked off. It is better to rename to avoid ambiguity.