### PR TITLE
Simplify metadataentities list.

### DIFF
--- a/.extlib/simplesamlphp/modules/saml/lib/Auth/Source/SP.php
+++ b/.extlib/simplesamlphp/modules/saml/lib/Auth/Source/SP.php
@@ -292,12 +292,10 @@ class SP extends \SimpleSAML\Auth\Source
         // Moodle customization. If we have multiple IdP's configured
         // then accept requests from the other IdP's even if they are
         // not the default IdP.
-        foreach ($saml2auth->metadataentities as $metadataurl => $idpentities) {
-            foreach ($idpentities as $key => $entity) {
-                if ($entity->entityid == $entityId) {
-                    $this->idp = null;
-                    break 2;
-                }
+        foreach ($saml2auth->metadataentities as $idpentity) {
+            if ($idpentity->entityid == $entityId) {
+                $this->idp = null;
+                break;
             }
         }
 

--- a/classes/auto_login.php
+++ b/classes/auto_login.php
@@ -153,17 +153,13 @@ class auto_login {
      * @param \auth_plugin_saml2 $auth Auth plugin
      */
     protected static function login(\auth_plugin_saml2 $auth) {
-        global $CFG, $FULLME, $SESSION, $SCRIPT, $saml2auth;
+        global $CFG, $FULLME, $SESSION, $SCRIPT;
 
         require(__DIR__ . '/../setup.php');
         $auth = get_auth_plugin('saml2');
 
         // Set the default IdP to be the first in the list. Used when dual login is disabled.
-        $arr = array_reverse($saml2auth->metadataentities);
-        $metadataentities = array_pop($arr);
-        $idpentity = array_pop($metadataentities);
-        $idp = md5($idpentity->entityid);
-        $SESSION->saml2idp = $idp;
+        $SESSION->saml2idp = reset($auth->metadataentities)->md5entityid;
 
         // Target URL is normally the same as current page, but if we got redirected to enrol.php
         // with a 'wants' URL, then that means if the login is successful we should try again at

--- a/classes/form/selectidp_dropdown.php
+++ b/classes/form/selectidp_dropdown.php
@@ -51,13 +51,7 @@ class selectidp_dropdown extends moodleform {
         $wants = $this->_customdata['wants'];
         $idpname = $this->_customdata['idpname'];
 
-        $idpentityids = array();
-
-        foreach ($metadataentities as $idpentities) {
-            foreach ($idpentities as $idpentityid => $idp) {
-                $idpentityids[$idpentityid] = $idp->name;
-            }
-        }
+        $idpentityids = array_combine(array_keys($metadataentities), array_column($metadataentities, 'name'));
 
         $mform->addElement('hidden', 'wants', $wants);
         $mform->setType('wants', PARAM_URL);

--- a/config/authsources.php
+++ b/config/authsources.php
@@ -30,23 +30,11 @@ global $saml2auth, $CFG, $SITE, $SESSION;
 
 $config = [];
 
-// Case for specifying no $SESSION IdP, select the first configured IdP as the default.
-$arr = array_reverse($saml2auth->metadataentities);
-$metadataentities = array_pop($arr);
-$idpentity = array_pop($metadataentities);
-
-// This must always be a valid saml entityId.
-$idpentityid = $idpentity->entityid;
-
-if (!empty($SESSION->saml2idp)) {
-    foreach ($saml2auth->metadataentities as $idpentities) {
-        foreach ($idpentities as $md5entityid => $idpentity) {
-            if ($SESSION->saml2idp === $md5entityid) {
-                $idpentityid = $idpentity->entityid;
-                break 2;
-            }
-        }
-    }
+if (!empty($SESSION->saml2idp) && array_key_exists($SESSION->saml2idp, $saml2auth->metadataentities)) {
+    $idpentityid = $saml2auth->metadataentities[$SESSION->saml2idp]->entityid;
+} else {
+    // Case for specifying no $SESSION IdP, select the first configured IdP as the default.
+    $idpentityid = reset($saml2auth->metadataentities)->entityid;
 }
 
 $config[$saml2auth->spname] = [

--- a/config/config.php
+++ b/config/config.php
@@ -29,10 +29,11 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG, $saml2auth, $saml2config;
 
 $metadatasources = [];
-foreach ($saml2auth->metadataentities as $metadataurl => $idpentities) {
-    $metadatasources[] = [
+foreach ($saml2auth->metadataentities as $idpentity) {
+    $metadataurlhash = md5($idpentity->metadataurl);
+    $metadatasources[$metadataurlhash] = [
         'type' => 'xml',
-        'file' => "$CFG->dataroot/saml2/" . md5($metadataurl) . ".idp.xml"
+        'file' => "$CFG->dataroot/saml2/" . $metadataurlhash . ".idp.xml"
     ];
 }
 
@@ -86,7 +87,7 @@ $config = array(
     'metadata.sign.certificate'     => $saml2auth->certcrt,
     'metadata.sign.privatekey'      => $saml2auth->certpem,
     'metadata.sign.privatekey_pass' => $saml2auth->config->privatekeypass,
-    'metadata.sources'              => $metadatasources,
+    'metadata.sources'              => array_values($metadatasources),
 
     'store.type' => !empty($CFG->auth_saml2_store) ? $CFG->auth_saml2_store : '\\auth_saml2\\store',
 

--- a/locallib.php
+++ b/locallib.php
@@ -456,23 +456,6 @@ function auth_saml2_get_idps($active = false, $asarray = false) {
 }
 
 /**
- * This helper function returns the default IdP if it is configured.
- * @return object The default IdP object, or NULL if there is no default IdP set.
- */
-function auth_saml2_get_default_idp() {
-    global $DB;
-
-    $defaultidps = $DB->get_records('auth_saml2_idps', array('activeidp' => 1, 'defaultidp' => 1));
-
-    // There should only be 1 but just in case we will use the first one.
-    $defaultidp = array_shift($defaultidps);
-    if ($defaultidp) {
-        $defaultidp->name = empty($defaultidp->displayname) ? $defaultidp->defaultname : $defaultidp->displayname;
-    }
-    return $defaultidp;
-}
-
-/**
  * This helper function processes the regenerate form.
  * Moved here so we can use it in a unit test.
  *

--- a/test.php
+++ b/test.php
@@ -46,13 +46,8 @@ if (!empty($idp)) {
 }
 
 if (empty($SESSION->saml2idp)) {
-    $arr = array_reverse($saml2auth->metadataentities);
-    $metadataentities = array_pop($arr);
-    $idpentity = array_pop($metadataentities);
-    $idp = md5($idpentity->entityid);
-
     // Specify the default IdP to use.
-    $SESSION->saml2idp = $idp;
+    $SESSION->saml2idp = reset($saml2auth->metadataentities)->md5entityid;
     echo '<p>Setting IdP to default</p>';
 }
 
@@ -69,17 +64,11 @@ echo '<p>Which IdP will be used? ' . s($SESSION->saml2idp);
 
 $auth = new SimpleSAML\Auth\Simple($saml2auth->spname);
 
-$idps = $saml2auth->metadataentities;
-
-foreach ($idps as $entityid => $info) {
-
-    $md5 = key($info);
-
+foreach ($saml2auth->metadataentities as $idpentity) {
     echo '<hr>';
-    echo "<h4>IDP: $entityid</h4>";
-    echo "<p>md5: $md5</p>";
-    echo "<p>check: " . md5($entityid) . "</p>";
-
+    echo "<h4>IDP: $idpentity->entityid</h4>";
+    echo "<p>md5: $idpentity->md5entityid</p>";
+    echo "<p>check: " . md5($idpentity->entityid) . "</p>";
 }
 
 if ($logout) {

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -1,0 +1,75 @@
+<?php
+// This file is part of SAML2 Authentication Plugin
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * auth_saml2 data generator.
+ *
+ * @package     auth_saml2
+ * @copyright   2021 Catalyst IT Australia {@link http://www.catalyst-au.net}
+ * @copyright   2021 Moodle Pty Ltd <support@moodle.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class auth_saml2_generator extends component_generator_base {
+
+    /**
+     * Number of entities created
+     * @var int
+     */
+    protected $entitiescount = 0;
+
+    /**
+     * To be called from data reset code only,
+     * do not use in tests.
+     * @return void
+     */
+    public function reset() {
+        $this->entitiescount = 0;
+    }
+
+    /**
+     * Creates new IdP entity
+     *
+     * @param array|stdClass $idprecord
+     * @return stdClass record from db
+     */
+    public function create_idp_entity($idprecord = []) : stdClass {
+        global $DB;
+        // Add IdP and configuration.
+        $entitycount = ++$this->entitiescount;
+        if (!array_key_exists('metadataurl', $idprecord)) {
+            $idprecord['metadataurl'] = 'https://idp.example.org/idp/shibboleth';
+        }
+        if (!array_key_exists('entityid', $idprecord)) {
+            $idprecord['entityid'] = "https://idp{$entitycount}.example.org/idp/shibboleth";
+        }
+        if (!array_key_exists('defaultname', $idprecord)) {
+            $idprecord['defaultname'] = "Test IdP {$entitycount}";
+        }
+        if (!array_key_exists('activeidp', $idprecord)) {
+            $idprecord['activeidp'] = 1;
+        }
+
+        $recordid = $DB->insert_record('auth_saml2_idps', $idprecord);
+        set_config('idpmetadata', $idprecord['metadataurl'], 'auth_saml2');
+        $auth = get_auth_plugin('saml2');
+        touch($auth->certcrt);
+        touch($auth->certpem);
+        touch($auth->get_file(md5($idprecord['metadataurl']). ".idp.xml"));
+        return $DB->get_record('auth_saml2_idps', ['id' => $recordid]);
+    }
+}

--- a/tests/generator_test.php
+++ b/tests/generator_test.php
@@ -1,0 +1,84 @@
+<?php
+// This file is part of SAML2 Authentication Plugin
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Unit tests for test data generator.
+ *
+ * @package     auth_saml2
+ * @category    test
+ * @group       auth_saml2
+ * @covers      \auth_saml2_generator
+ * @copyright   2021 Catalyst IT Australia {@link http://www.catalyst-au.net}
+ * @copyright   2021 Moodle Pty Ltd <support@moodle.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class generator_testcase extends \advanced_testcase {
+    /**
+     * Set up
+     */
+    public function setUp(): void {
+        $this->resetAfterTest();
+    }
+
+    /**
+     * Get generator
+     *
+     * @return auth_saml2_generator
+     */
+    protected function get_generator(): auth_saml2_generator {
+        return $this->getDataGenerator()->get_plugin_generator('auth_saml2');
+    }
+
+    /**
+     * Test create_idp_entity
+     */
+    public function test_create_idp_entity(): void {
+        // Sanity check.
+        $auth = get_auth_plugin('saml2');
+        $this->assertFalse($auth->is_configured());
+        $this->assertCount(0, $auth->metadataentities);
+
+        // Create one entity, check fields.
+        $entity1 = $this->get_generator()->create_idp_entity();
+        $auth = get_auth_plugin('saml2');
+        $this->assertTrue($auth->is_configured());
+        $this->assertCount(1, $auth->metadataentities);
+        $this->assertEquals($entity1->defaultname, reset($auth->metadataentities)->name);
+        $this->assertEquals($entity1->entityid, reset($auth->metadataentities)->entityid);
+        $this->assertEquals($entity1->metadataurl, reset($auth->metadataentities)->metadataurl);
+
+        // Create another entity.
+        $this->get_generator()->create_idp_entity();
+        $auth = get_auth_plugin('saml2');
+        $this->assertCount(2, $auth->metadataentities);
+        $this->assertEqualsCanonicalizing(['Test IdP 1', 'Test IdP 2'], array_column($auth->metadataentities, 'name'));
+
+        // Create non-active entity, it should not be added to metadataentities.
+        $this->get_generator()->create_idp_entity(['activeidp' => 0]);
+        $auth = get_auth_plugin('saml2');
+        $this->assertCount(2, $auth->metadataentities);
+        $this->assertEqualsCanonicalizing(['Test IdP 1', 'Test IdP 2'], array_column($auth->metadataentities, 'name'));
+
+        // Create custom named entity.
+        $this->get_generator()->create_idp_entity(['defaultname' => 'Generator']);
+        $auth = get_auth_plugin('saml2');
+        $this->assertCount(3, $auth->metadataentities);
+        $this->assertEqualsCanonicalizing(['Test IdP 1', 'Test IdP 2', 'Generator'], array_column($auth->metadataentities, 'name'));
+    }
+}

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -294,7 +294,6 @@ class auth_saml2_locallib_testcase extends advanced_testcase {
         $auth->metadataentities = [
             md5('idp') => (object)[
                 'whitelist' => $whitelist,
-                'activeidp' => true,
                 'md5entityid' => md5('idp'),
             ]
         ];

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -276,10 +276,12 @@ class auth_saml2_locallib_testcase extends advanced_testcase {
      * Test test_should_login_redirect
      *
      * @dataProvider check_whitelisted_ip_redirect_testcases
+     * @param string $saml
+     * @param string $remoteip
      * @param string $whitelist
      * @param bool $expected The expected return value
      */
-    public function test_check_whitelisted_ip_redirect($saml, $remoteip, $active, $whitelist, $expected) {
+    public function test_check_whitelisted_ip_redirect($saml, $remoteip, $whitelist, $expected) {
         $this->resetAfterTest();
 
         // Setting an address here as getremoteaddr() will return default 0.0.0.0 which then is ignored by the address_in_subnet
@@ -290,11 +292,10 @@ class auth_saml2_locallib_testcase extends advanced_testcase {
         $auth = get_auth_plugin('saml2');
 
         $auth->metadataentities = [
-            md5('idp') => [
-                'entity' => (object)[
-                        'whitelist' => $whitelist,
-                        'activeidp' => $active
-                ]
+            md5('idp') => (object)[
+                'whitelist' => $whitelist,
+                'activeidp' => true,
+                'md5entityid' => md5('idp'),
             ]
         ];
 
@@ -307,18 +308,17 @@ class auth_saml2_locallib_testcase extends advanced_testcase {
     }
 
     /**
-     * Dataprovider for the test_check_whitelisted_ip_redirect testcase
+     * Dataprovider for {@see self::test_check_whitelisted_ip_redirect} testcase
      *
-     * @return array of testcases
+     * @return array
      */
     public function check_whitelisted_ip_redirect_testcases() {
         return [
-            'saml off, no ip, active idp, no redirect'              => ['off', '1.2.3.4', true, '', false],
-            'saml not specified, active idp, junk, no redirect'     => [null, '1.2.3.4', true, 'qwer1234!@#qwer', false],
-            'saml not specified, active idp, junk+ip, yes redirect' => [null, '1.2.3.4', true, "qwer1234!@#qwer\n1.2.3.4", true],
-            'saml not specified, active idp, localip, yes redirect' => [null, '1.2.3.4', true, "127.0.0.\n1.", true],
-            'saml not specified, disabled idp, localip, no redirect' => [null, '1.2.3.4', false, "127.0.0.\n1.", false],
-            'saml not specified, active idp, wrongip, no redirect' => [null, '4.3.2.1', true, "127.0.0.\n1.", false],
+            'saml off, no ip, no redirect'              => ['off', '1.2.3.4', '', false],
+            'saml not specified, junk, no redirect'     => [null, '1.2.3.4', 'qwer1234!@#qwer', false],
+            'saml not specified, junk+ip, yes redirect' => [null, '1.2.3.4', "qwer1234!@#qwer\n1.2.3.4", true],
+            'saml not specified, localip, yes redirect' => [null, '1.2.3.4', "127.0.0.\n1.", true],
+            'saml not specified, wrongip, no redirect' => [null, '4.3.2.1', "127.0.0.\n1.", false],
         ];
     }
 


### PR DESCRIPTION
There is no clear reason of structuring `metadataentities` array using two dimensions. This patch removes numerous duplicated code snippets where `metadataentities` array walk was required to check certain entity properties or find out default entity. The patch also removes use of global `$saml2auth` variable inside the same class it contains instance of.

This also removes `auth_saml2_get_default_idp` function which no longer required as default entity can be defined in class contractor while populating `metadataentities` list.

Constructor unit test is included and generator is added and used to simplify mock entity creation.

There is also minor `whitelisted_ip_redirect` test change. Removing excessive test for "inactive" entity. `$auth->metadataentities` always contains active IdPs (that was always the case).