### PR TITLE
Make it possible to parse **HUGE** XML documents

### DIFF
--- a/classes/admin/setting_idpmetadata.php
+++ b/classes/admin/setting_idpmetadata.php
@@ -219,7 +219,7 @@ class setting_idpmetadata extends admin_setting_configtextarea {
 
         $rawxml = $idp->rawxml;
 
-        if (!$xml->loadXML($rawxml)) {
+        if (!$xml->loadXML($rawxml, LIBXML_PARSEHUGE)) {
             $errors = libxml_get_errors();
             $lines = explode("\n", $rawxml);
             $msg = '';


### PR DESCRIPTION
Make it possible to parse **HUGE** XML documents, like the one provided by „German National Research and Education Network“ for Authentication and authorization infrastructure (see https://github.com/catalyst/moodle-auth_saml2/issues/543).