### PR TITLE
Unset session wantsurl on login error page.

### DIFF
--- a/classes/auth.php
+++ b/classes/auth.php
@@ -316,19 +316,22 @@ class auth extends \auth_plugin_base {
      * @param string $msg The error message.
      */
     public function error_page($msg) {
-        global $PAGE, $OUTPUT;
+        global $PAGE, $OUTPUT, $SESSION;
 
-        $logouturl = new moodle_url('/auth/saml2/logout.php');
+        // Clean up $SESSION->wantsurl that was set explicitly in {@see login.php},
+        // we don't go anywhere.
+        unset($SESSION->wantsurl);
 
         $PAGE->set_context(\context_system::instance());
         $PAGE->set_url('/auth/saml2/error.php');
         $PAGE->set_title(get_string('error', 'auth_saml2'));
         $PAGE->set_heading(get_string('error', 'auth_saml2'));
         echo $OUTPUT->header();
-        echo $OUTPUT->box($msg);
-        echo \html_writer::link($logouturl, get_string('logout'));
+        echo $OUTPUT->box($msg, 'generalbox', 'notice');
+        $logouturl = new moodle_url('/auth/saml2/logout.php');
+        echo $OUTPUT->single_button($logouturl, get_string('logout'), 'get');
         echo $OUTPUT->footer();
-        exit;
+        exit(1);
     }
 
     /**


### PR DESCRIPTION
So that it does not get into play where we don't expect it. In particular to prevent weirdness on consequent login as this is taken into account for login page IdP list rendering.

To replicate issue without this patch applied, make sure there are two IdPs and user account creating is not permitted. On the login page check that IdPs URLs have different idp hashes. Login with one, get to error page that indicates that user logged in into SAML, but did not log in to Moodle. Navigate to Moodle login page again and observe that both IdP have the same URL (the last one used).