### PR TITLE
Pass an empty string instead of a null value when there is no IDP sesion value

### DIFF
--- a/classes/auth.php
+++ b/classes/auth.php
@@ -613,7 +613,7 @@ class auth extends \auth_plugin_base {
 
         // Moodle Workplace - Check IdP's tenant availability, for new user pre-allocate to tenant.
         component_class_callback('\tool_tenant\local\auth\saml2\manager', 'complete_login_hook',
-            [$SESSION->saml2idp ?? null, $uid, $user]);
+            [$SESSION->saml2idp ?? '', $uid, $user]);
 
         $newuser = false;
         if (!$user) {

--- a/tests/auth_test.php
+++ b/tests/auth_test.php
@@ -29,7 +29,7 @@ defined('MOODLE_INTERNAL') || die();
  * @copyright   2021 Moodle Pty Ltd <support@moodle.com>
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class auth_testcase extends \advanced_testcase {
+class auth_test extends \advanced_testcase {
     /**
      * Set up
      */


### PR DESCRIPTION
As the callback signature expects a string type value

Fixes #588