### PR TITLE
Cookie samesite config 39

### DIFF
--- a/.extlib/simplesamlphp/lib/SimpleSAML/Utils/HTTP.php
+++ b/.extlib/simplesamlphp/lib/SimpleSAML/Utils/HTTP.php
@@ -17,6 +17,49 @@ use SimpleSAML\XHTML\Template;
 class HTTP
 {
     /**
+     * Determine if the user agent can support cookies being sent with SameSite equal to "None".
+     * Browsers with out support may drop the cookie and or treat is a stricter setting
+     * Browsers with support may have additional requirements on setting it on non-secure websites.
+     *
+     * Based on the Azure teams experience rolling out support and Chromium's advice
+     * https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
+     * https://www.chromium.org/updates/same-site/incompatible-clients
+     * @return bool true if user agent supports a None value for SameSite.
+     */
+    public static function canSetSameSiteNone(): bool {
+        $useragent = $_SERVER['HTTP_USER_AGENT'] ?? null;
+        if (!$useragent) {
+            return true;
+        }
+        // All iOS 12 based browsers have no support
+        if (strpos($useragent, "CPU iPhone OS 12") !== false || strpos($useragent, "iPad; CPU OS 12") !== false) {
+            return false;
+        }
+
+        // Safari Mac OS X 10.14 has no support
+        // - Safari on Mac OS X.
+        if (strpos($useragent, "Macintosh; Intel Mac OS X 10_14") !== false) {
+            // regular safari
+            if (strpos($useragent, "Version/") !== false && strpos($useragent, "Safari") !== false) {
+                return false;
+            } else if (preg_match('|AppleWebKit/[\.\d]+ \(KHTML, like Gecko\)$|', $useragent)) {
+                return false;
+            }
+        }
+
+        // Chrome based UCBrowser may have support (>= 12.13.2) even though its chrome version is old
+        $matches = [];
+        if (preg_match('|UCBrowser/(\d+\.\d+\.\d+)[\.\d]*|', $useragent, $matches)) {
+            return version_compare($matches[1], '12.13.2', '>=');
+        }
+
+        // Chrome 50-69 may have broken SameSite=None and don't require it to be set
+        if (strpos($useragent, "Chrome/5") !== false || strpos($useragent, "Chrome/6") !== false) {
+            return false;
+        }
+        return true;
+    }
+    /**
      * Obtain a URL where we can redirect to securely post a form with the given data to a specific destination.
      *
      * @param string $destination The destination URL.

--- a/.extlib/simplesamlphp/tests/lib/SimpleSAML/Utils/HTTPTest.php
+++ b/.extlib/simplesamlphp/tests/lib/SimpleSAML/Utils/HTTPTest.php
@@ -553,4 +553,57 @@ class HTTPTest extends ClearStateTestCase
         $this->assertRegExp('/\b[Ss]ame[Ss]ite=Lax(;|$)/', $headers[2]);
         $this->assertRegExp('/\b[Ss]ame[Ss]ite=Strict(;|$)/', $headers[3]);
     }
+
+    /**
+     * Test detecting if user agent supports None
+     * @dataProvider detectSameSiteProvider
+     * @param null|string $userAgent The user agent. Null means not set, like with CLI
+     * @param bool $supportsNone None can be set as a SameSite flag
+     */
+    public function testDetectSameSiteNoneBehavior(string $userAgent = null, bool $supportsNone)
+    {
+        if ($userAgent) {
+            $_SERVER['HTTP_USER_AGENT'] = $userAgent;
+        }
+        $this->assertEquals($supportsNone, HTTP::canSetSameSiteNone(), $userAgent ?? 'No user agent set');
+    }
+
+    public function detectSameSiteProvider(): array
+    {
+        // @codingStandardsIgnoreStart
+        return [
+            [null, true],
+            ['some-new-browser', true],
+            //Browsers that can handle 'None'
+            // Chrome
+            ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.70 Safari/537.36', true],
+            // Chome on windows
+            ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36', true],
+            // Chrome linux
+            ['Mozilla/5.0 (X11; HasCodingOs 1.0; Linux x64) AppleWebKit/637.36 (KHTML, like Gecko) Chrome/70.0.3112.101 Safari/637.36 HasBrowser/5.0', true],
+            // Safari iOS 13
+            ['Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.2 Mobile/15E148 Safari/604.1', true],
+            // Mac OS X with support
+            ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.1 Safari/605.1.15', true],
+            // UC Browser with support
+            ['Mozilla/5.0 (Linux; U; Android 9; en-US; SM-A705FN Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.2.1208 Mobile Safari/537.36', true],
+            ['Mozilla/5.0 (Linux; U; Android 10; en-US; RMX2020 Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.5.1209 Mobile Safari/537.36', true],
+            // Embedded Mac with support
+            ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko)', true],
+            // Browser without support
+            // Old Safari on mac
+            ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 Safari/605.1.15', false],
+            // Old Safari on iOS 12 (phone and ipad
+            ['Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1 Mobile/15E148 Safari/604.1', false],
+            ['Mozilla/5.0 (iPad; CPU OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/16A5288q Safari/605.1.15', false],
+            // Chromium without support
+            ['Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/65.0.3325.181 Chrome/65.0.3325.181 Safari/537.36', false],
+            // UC Browser without support
+            ['Mozilla/5.0 (Linux; U; Android 8.1.0; zh-CN; EML-AL00 Build/HUAWEIEML-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 baidu.sogo.uc.UCBrowser/11.9.4.974 UWS/2.13.1.48 Mobile Safari/537.36 AliApp(DingTalk/4.5.11) com.alibaba.android.rimet/10487439 Channel/227200 language/zh-CN', false],
+            ['Mozilla/5.0 (Linux; U; Android 7.1.1; en-US; CPH1723 Build/N6F26Q) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.0.1207 Mobile Safari/537.36', false],
+            // old embedded browser
+            ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/605.1.15 (KHTML, like Gecko)', false]
+        ];
+        // @codingStandardsIgnoreEnd
+    }
 }

--- a/config/config.php
+++ b/config/config.php
@@ -36,18 +36,21 @@ foreach ($saml2auth->metadataentities as $idpentity) {
         'file' => "$CFG->dataroot/saml2/" . $metadataurlhash . ".idp.xml"
     ];
 }
-// Check if the config for samesite is set otherwise default to 'Lax'
-$samesitedefault = (isset($CFG->cookiesamesite) ? $CFG->cookiesamesite : 'lax');
-switch (strtolower($samesitedefault)) {
-    case 'none':
-        $samesitedefault = \SimpleSAML\Utils\HTTP::canSetSameSiteNone() ? 'None' : 'Lax';
-        break;
-    case 'lax':
-    case 'strict':
-        $samesitedefault = ucfirst($samesitedefault);
-        break;
-    default:
-        $samesitedefault = 'Lax';
+
+// Check if the config for samesite is set otherwise default to null
+$samesitedefault = (isset($CFG->cookiesamesite) ? $CFG->cookiesamesite : null);
+if (!is_null($samesitedefault)) {
+    switch (strtolower($samesitedefault)) {
+        case 'none':
+            $samesitedefault = \SimpleSAML\Utils\HTTP::canSetSameSiteNone() ? 'None' : null;
+            break;
+        case 'lax':
+        case 'strict':
+            $samesitedefault = ucfirst($samesitedefault);
+            break;
+        default:
+            $samesitedefault = 'Lax';
+    }
 }
 
 $remoteip = getremoteaddr();

--- a/config/config.php
+++ b/config/config.php
@@ -37,6 +37,11 @@ foreach ($saml2auth->metadataentities as $idpentity) {
     ];
 }
 
+$samesitedefault = (!empty($CFG->cookiesamesite) ? $CFG->cookiesamesite : 'Lax');
+if ($samesitedefault == "None") {
+    $samesitedefault = \SimpleSAML\Utils\HTTP::canSetSameSiteNone() ? 'None' : null;
+}
+
 $remoteip = getremoteaddr();
 
 $config = array(
@@ -71,6 +76,7 @@ $config = array(
     'session.cookie.path'     => $CFG->sessioncookiepath,
     'session.cookie.domain'   => null,
     'session.cookie.secure'   => !empty($CFG->cookiesecure),
+    'session.cookie.samesite' => $samesitedefault,
     'session.cookie.lifetime' => 0,
 
     'session.phpsession.cookiename' => null,

--- a/config/config.php
+++ b/config/config.php
@@ -36,10 +36,18 @@ foreach ($saml2auth->metadataentities as $idpentity) {
         'file' => "$CFG->dataroot/saml2/" . $metadataurlhash . ".idp.xml"
     ];
 }
-
-$samesitedefault = (!empty($CFG->cookiesamesite) ? $CFG->cookiesamesite : 'Lax');
-if ($samesitedefault == "None") {
-    $samesitedefault = \SimpleSAML\Utils\HTTP::canSetSameSiteNone() ? 'None' : null;
+// Check if the config for samesite is set otherwise default to 'Lax'
+$samesitedefault = (isset($CFG->cookiesamesite) ? $CFG->cookiesamesite : 'lax');
+switch (strtolower($samesitedefault)) {
+    case 'none':
+        $samesitedefault = \SimpleSAML\Utils\HTTP::canSetSameSiteNone() ? 'None' : 'Lax';
+        break;
+    case 'lax':
+    case 'strict':
+        $samesitedefault = ucfirst($samesitedefault);
+        break;
+    default:
+        $samesitedefault = 'Lax';
 }
 
 $remoteip = getremoteaddr();


### PR DESCRIPTION
Allows a Moodle config option for samesite attribute with useragent checks for the support of 'none'