### PR TITLE
 SOAP binding / backend logout work in progress proposal

### DIFF
--- a/.extlib/simplesamlphp/lib/SimpleSAML/Session.php
+++ b/.extlib/simplesamlphp/lib/SimpleSAML/Session.php
@@ -736,12 +736,9 @@ class Session implements \Serializable, Utils\ClearableState
         assert(isset($this->authData[$authority]));
 
         if (empty($this->authData[$authority]['LogoutHandlers'])) {
-            if (empty($this->authData[$authority]['Attributes']['username'][0])) {
-                return;
-            } else {
-                call_user_func(['\auth_saml2\api', 'logout_from_idp_back_channel'], $this->authData[$authority]['Attributes']['username'][0], $this->sessionId);
-            }
+            return;
         }
+        
         foreach ($this->authData[$authority]['LogoutHandlers'] as $handler) {
             // verify that the logout handler is a valid function
             if (!is_callable($handler)) {
@@ -750,10 +747,9 @@ class Session implements \Serializable, Utils\ClearableState
 
                 throw new \Exception(
                     'Logout handler is not a valid function: ' . $classname . '::' .
-                    $functionname
+                        $functionname
                 );
             }
-
             // call the logout handler
             call_user_func($handler);
         }

--- a/.extlib/simplesamlphp/lib/SimpleSAML/Session.php
+++ b/.extlib/simplesamlphp/lib/SimpleSAML/Session.php
@@ -736,7 +736,11 @@ class Session implements \Serializable, Utils\ClearableState
         assert(isset($this->authData[$authority]));
 
         if (empty($this->authData[$authority]['LogoutHandlers'])) {
-            return;
+            if (empty($this->authData[$authority]['Attributes']['username'][0])) {
+                return;
+            } else {
+                call_user_func(['\auth_saml2\api', 'logout_from_idp_back_channel'], $this->authData[$authority]['Attributes']['username'][0], $this->sessionId);
+            }
         }
         foreach ($this->authData[$authority]['LogoutHandlers'] as $handler) {
             // verify that the logout handler is a valid function

--- a/.extlib/simplesamlphp/modules/saml/www/sp/saml2-logout.php
+++ b/.extlib/simplesamlphp/modules/saml/www/sp/saml2-logout.php
@@ -130,6 +130,7 @@ if ($message instanceof \SAML2\LogoutResponse) {
     $dst = $idpMetadata->getEndpointPrioritizedByBinding(
         'SingleLogoutService',
         [
+            \SAML2\Constants::BINDING_SOAP,
             \SAML2\Constants::BINDING_HTTP_REDIRECT,
             \SAML2\Constants::BINDING_HTTP_POST
         ]
@@ -143,8 +144,9 @@ if ($message instanceof \SAML2\LogoutResponse) {
             $dst = $dst['Location'];
         }
         $binding->setDestination($dst);
+    } else {
+        $lr->setDestination($dst['Location']);
     }
-    $lr->setDestination($dst);
 
     $binding->send($lr);
 } else {

--- a/classes/api.php
+++ b/classes/api.php
@@ -39,17 +39,16 @@ class api {
         require_logout();
     }
 
-    public static function logout_from_idp_back_channel($username, $sessionId): void {
-        global $DB;
-        if (isset($sessionId)) {
-            $DB->delete_records('auth_saml2_kvstore', array('k' => $sessionId));
+    public static function logout_from_idp_back_channel(): void
+    {
+        global $DB, $sp_sessionId;
+
+        if (isset($sp_sessionId)) {
+            $DB->delete_records('auth_saml2_kvstore', array('k' => $sp_sessionId));
+            $session = \SimpleSAML\Session::getSession($sp_sessionId);
+            \core\session\manager::kill_session($session->moodle_session_id);
         }
 
-        $userid = $DB->get_record('user', array('username' => $username), 'id');        
-        $mdsessionids = $DB->get_records('sessions', array('userid' => $userid->id), 'sid DESC', 'sid');
-        foreach ($mdsessionids as $mdsessionid) {
-            $DB->delete_records('sessions', array('sid' => $mdsessionid->sid));
-        }
     }
 
     /**

--- a/classes/api.php
+++ b/classes/api.php
@@ -39,6 +39,19 @@ class api {
         require_logout();
     }
 
+    public static function logout_from_idp_back_channel($username, $sessionId): void {
+        global $DB;
+        if (isset($sessionId)) {
+            $DB->delete_records('auth_saml2_kvstore', array('k' => $sessionId));
+        }
+
+        $userid = $DB->get_record('user', array('username' => $username), 'id');        
+        $mdsessionids = $DB->get_records('sessions', array('userid' => $userid->id), 'sid DESC', 'sid');
+        foreach ($mdsessionids as $mdsessionid) {
+            $DB->delete_records('sessions', array('sid' => $mdsessionid->sid));
+        }
+    }
+
     /**
      * SP logout callback. Called in case of normal Moodle logout.
      * {@see auth::logoutpage_hook}

--- a/classes/auth.php
+++ b/classes/auth.php
@@ -726,6 +726,12 @@ class auth extends \auth_plugin_base {
         $USER->site = $CFG->wwwroot;
         set_moodle_cookie($USER->username);
 
+        $moodle_session_id = session_id();
+        $saml_session = \SimpleSAML\Session::getSessionFromRequest();
+        $saml_session->moodle_session_id = $moodle_session_id;
+        $saml_session_handler = \SimpleSAML\SessionHandler::getSessionHandler();
+        $saml_session_handler->saveSession($saml_session);
+
         $wantsurl = core_login_get_return_url();
         // If we are not on the page we want, then redirect to it (unless this is CLI).
         if ( qualified_me() !== false && qualified_me() !== $wantsurl ) {

--- a/sp/saml2-logout.php
+++ b/sp/saml2-logout.php
@@ -54,6 +54,25 @@ try {
     // user out in Moodle.
     if (!is_null($session->getAuthState($saml2auth->spname))) {
         $session->registerLogoutHandler($saml2auth->spname, '\auth_saml2\api', 'logout_from_idp_front_channel');
+    } else {
+         try {
+            $binding = \SAML2\Binding::getCurrentBinding();
+        } catch (\Exception $e) {
+            // TODO: look for a specific exception
+            // This is dirty. Instead of checking the message of the exception, \SAML2\Binding::getCurrentBinding() should throw
+            // an specific exception when the binding is unknown, and we should capture that here
+            if ($e->getMessage() === 'Unable to find the current binding.') {
+                throw new \SimpleSAML\Error\Error('SLOSERVICEPARAMS', $e, 400);
+            } else {
+                throw $e; // do not ignore other exceptions!
+            }
+        }
+        $message = $binding->receive();
+
+        if ($message instanceof \SAML2\LogoutRequest) {
+            //Todo : parse xmlbody, get sp sessionid/moodle userid, and register logoutHandler from here ?
+            //For the time being the call to the specific logout function is done with 3 lines in extlib.. session.php
+        }
     }
 
     require('../.extlib/simplesamlphp/modules/saml/www/sp/saml2-logout.php');


### PR DESCRIPTION
This is a work in progress / experimental proposal for a backend channel logout. It works in our environment.

I understand that any added code and the call to the specific logout function needs to be pulled out from the simplesamphp library. But to be able to get sessionids and register a logouthandler in sp/saml2-logout.php, we need to parse the xml message and pull quite a bit of the code from the extlib saml2-logout.php and logoutStore.php into sp/saml2-logout.php. It somehow defeats the purpose of keeping the plugin independent from the simplesamphp library.

I will keep on looking for a better solution.

(and sorry for the earlier mess... please remove the unnecessary zip files i posted on the subject)