### PR TITLE
Fix global $PAGE error when using the tester page

### DIFF
--- a/classes/auth.php
+++ b/classes/auth.php
@@ -1043,6 +1043,7 @@ class auth extends \auth_plugin_base {
      * A simple GUI tester which shows the raw API output
      */
     public function test_settings() {
+        global $PAGE;
         include(__DIR__.'/../tester.php');
     }
 


### PR DESCRIPTION
Although this is a fix to master, the error was occurring on a Totara 12 site. I assume it isn't working properly elsewhere either. This is a shortest-path fix for #591 which simply reinstates the functionality without refactoring or improving anything.