### PR TITLE
Removing master branch from MOODLE_39_STABLE CI

### DIFF
--- a/.github/workflows/39-master.yml
+++ b/.github/workflows/39-master.yml
@@ -42,17 +42,11 @@ jobs:
       fail-fast: false
       matrix:
         database: ['pgsql']
-        moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE', 'master']
+        moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE']
         php: ['7.2', '7.4']
         exclude:
-          - moodle-branch: master
-            php: 7.2
           - moodle-branch: MOODLE_311_STABLE
             php: 7.2
-        include:
-          - moodle-branch: master
-            php: 7.4
-            database: mariadb
 
     steps:
       - name: Check out repository code


### PR DESCRIPTION
CI tests should not be running against master.