### PR TITLE
Add a case insensitive mapping option

### DIFF
--- a/classes/admin/saml2_settings.php
+++ b/classes/admin/saml2_settings.php
@@ -51,4 +51,10 @@ abstract class saml2_settings {
     const OPTION_AUTO_LOGIN_SESSION = 1;
 
     const OPTION_AUTO_LOGIN_COOKIE = 2;
+
+    const OPTION_TOLOWER_EXACT = 0;
+
+    const OPTION_TOLOWER_LOWER_CASE = 1;
+
+    const OPTION_TOLOWER_CASE_INSENSITIVE = 2;
 }

--- a/classes/auth.php
+++ b/classes/auth.php
@@ -72,7 +72,7 @@ class auth extends \auth_plugin_base {
         'anyauth'            => 1,
         'idpattr'            => 'uid',
         'mdlattr'            => 'username',
-        'tolower'            => 0,
+        'tolower'            => saml2_settings::OPTION_TOLOWER_EXACT,
         'autocreate'         => 0,
         'spmetadatasign'     => true,
         'showidplink'        => true,
@@ -608,11 +608,16 @@ class auth extends \auth_plugin_base {
         // Find Moodle user.
         $user = false;
         foreach ($attributes[$attr] as $uid) {
-            if ($this->config->tolower) {
+            $insensitive = false;
+            if ($this->config->tolower == saml2_settings::OPTION_TOLOWER_LOWER_CASE) {
                 $this->log(__FUNCTION__ . " to lowercase for $uid");
                 $uid = strtolower($uid);
             }
-            if ($user = user_extractor::get_user($this->config->mdlattr, $uid)) {
+            if ($this->config->tolower == saml2_settings::OPTION_TOLOWER_CASE_INSENSITIVE) {
+                $this->log(__FUNCTION__ . " case insensitive compare for $key => $uid");
+                $insensitive = true;
+            }
+            if ($user = user_extractor::get_user($this->config->mdlattr, $uid, $insensitive)) {
                 // We found a user.
                 break;
             }

--- a/classes/user_extractor.php
+++ b/classes/user_extractor.php
@@ -42,10 +42,11 @@ class user_extractor {
      *
      * @param string $fieldname Field name to search by.
      * @param string $fieldvalue Field value to search by.
+     * @param bool $insensitive Whether to use case insensitive match.
      *
      * @return mixed False, or A {@link $USER} object.
      */
-    public static function get_user(string $fieldname, string $fieldvalue) {
+    public static function get_user(string $fieldname, string $fieldvalue, bool $insensitive = false) {
         global $DB, $CFG;
 
         if (user_fields::is_custom_profile_field($fieldname)) {
@@ -55,8 +56,11 @@ class user_extractor {
 
             $joins = " LEFT JOIN {user_info_field} f ON f.shortname = :fieldname ";
             $joins .= " LEFT JOIN {user_info_data} d ON d.fieldid = f.id AND d.userid = u.id ";
-            $fieldsql = " AND d.data = :fieldvalue";
-
+            if ($insensitive) {
+                $fieldsql = " AND LOWER(d.data) = LOWER(:fieldvalue)";
+            } else {
+                $fieldsql = " AND d.data = :fieldvalue";
+            }
             $params['fieldname'] = $fieldname;
             $params['fieldvalue'] = $fieldvalue;
             $params['mnethostid'] = $CFG->mnet_localhost_id;

--- a/lang/en/auth_saml2.php
+++ b/lang/en/auth_saml2.php
@@ -171,8 +171,14 @@ $string['test_auth_button_logout'] = 'IdP Logout';
 $string['test_auth_str'] = 'Test isAuthenticated and login';
 $string['test_noticetestrequirements'] = 'In order to use this test, plugin needs to be configired, enabled and debugging mode should be enabled in plugin settings.';
 $string['test_passive_str'] = 'Test using isPassive';
-$string['tolower_help'] = 'Apply lowercase to IdP attribute before matching?';
-$string['tolower'] = 'Lowercase';
+$string['tolower'] = 'Case matching';
+$string['tolower:exact'] = 'Exact';
+$string['tolower:lowercase'] = 'Lower case';
+$string['tolower:caseinsensitive'] = 'Case insensitive';
+$string['tolower_help'] = '
+<p>Exact: match is case sensitive (default).</p>
+<p>Lower case: applies lower case to the IdP attribute before matching.</p>
+<p>Case insensitive: ignore case when matching.</p>';
 $string['wrongauth'] = 'You have logged in successfully as \'{$a}\' but are not authorized to access Moodle.';
 $string['auth_data_mapping'] = 'Data mapping';
 $string['auth_fieldlockfield'] = 'Lock value ({$a})';

--- a/settings.php
+++ b/settings.php
@@ -236,11 +236,17 @@ if ($ADMIN->fulltree) {
             'username', user_fields::get_supported_fields()));
 
     // Lowercase.
+    $toloweroptions = [
+        saml2_settings::OPTION_TOLOWER_EXACT => get_string('tolower:exact', 'auth_saml2'),
+        saml2_settings::OPTION_TOLOWER_LOWER_CASE => get_string('tolower:lowercase', 'auth_saml2'),
+        saml2_settings::OPTION_TOLOWER_CASE_INSENSITIVE => get_string('tolower:caseinsensitive', 'auth_saml2'),
+    ];
     $settings->add(new admin_setting_configselect(
             'auth_saml2/tolower',
             get_string('tolower', 'auth_saml2'),
             get_string('tolower_help', 'auth_saml2'),
-            0, $yesno));
+            saml2_settings::OPTION_TOLOWER_EXACT,
+            $toloweroptions));
 
     // Autocreate Users.
     $settings->add(new admin_setting_configselect(

--- a/tests/user_extractor_test.php
+++ b/tests/user_extractor_test.php
@@ -155,6 +155,40 @@ class auth_saml2_user_extractor_test extends advanced_testcase {
     }
 
     /**
+     * Tests for case insensitive match.
+     */
+    public function test_get_user_case_insensitive() {
+        $this->resetAfterTest();
+
+        // Arrange data
+        $field = $this->add_user_profile_field('vehicleplate', 'text', true);
+        $expecteduser = $this->getDataGenerator()->create_user();
+        profile_save_data((object)['id' => $expecteduser->id, 'profile_field_vehicleplate' => 'HD4999']);
+
+        // Should match with same case.
+        $actualuser = user_extractor::get_user('profile_field_vehicleplate', 'HD4999', true);
+        $this->assertNotFalse($actualuser);
+        $this->assertSame($expecteduser->id, $actualuser->id);
+
+        // Should match with different case.
+        $actualuser = user_extractor::get_user('profile_field_vehicleplate', 'hd4999', true);
+        $this->assertNotFalse($actualuser);
+        $this->assertSame($expecteduser->id, $actualuser->id);
+
+        // Should not match with different value (obviously).
+        $actualuser = user_extractor::get_user('profile_field_vehicleplate', 'Some other value entirely', true);
+        $this->assertFalse($actualuser);
+
+        // Should not match when case sensitive.
+        $actualuser = user_extractor::get_user('profile_field_vehicleplate', 'hd4999', false);
+        $this->assertFalse($actualuser);
+
+        // Should not match by default (case sensitive = false).
+        $actualuser = user_extractor::get_user('profile_field_vehicleplate', 'hd4999');
+        $this->assertFalse($actualuser);
+    }
+
+    /**
      * Test we can extract users using custom profile fields when found multiple users.
      */
     public function test_get_user_by_custom_profile_field_when_multiple_users_found() {


### PR DESCRIPTION
Initially for client usage on WR 370283; starting with `MOODLE_39_STABLE` and backport later.