### PR TITLE
T12support part 1

### DIFF
--- a/tests/auth_test.php
+++ b/tests/auth_test.php
@@ -375,7 +375,11 @@ class auth_test extends \advanced_testcase {
             $this->fail('Exception expected');
         } catch (\coding_exception $e) {
             // Validate reason.
-            $this->assertStringContainsString(get_string('noattribute', 'auth_saml2', 'blabla'), $e->getMessage());
+            if (method_exists($this, 'assertStringContainsString')) {
+                $this->assertStringContainsString(get_string('noattribute', 'auth_saml2', 'blabla'), $e->getMessage());
+            } else {
+                $this->assertContains(get_string('noattribute', 'auth_saml2', 'blabla'), $e->getMessage());
+            }
         }
 
         // Checking that the event contains the expected values.
@@ -401,7 +405,11 @@ class auth_test extends \advanced_testcase {
             $this->fail('Exception expected');
         } catch (\coding_exception $e) {
             // Validate reason.
-            $this->assertStringContainsString(get_string('flagmessage_default', 'auth_saml2'), $e->getMessage());
+            if (method_exists($this, 'assertStringContainsString')) {
+                $this->assertStringContainsString(get_string('flagmessage_default', 'auth_saml2'), $e->getMessage());
+            } else {
+                $this->assertContains(get_string('flagmessage_default', 'auth_saml2'), $e->getMessage());
+            }
         }
 
         // Checking that the event contains the expected values.
@@ -428,7 +436,11 @@ class auth_test extends \advanced_testcase {
             $this->fail('Exception expected');
         } catch (\coding_exception $e) {
             // Validate reason.
-            $this->assertStringContainsString(get_string('emailtaken', 'auth_saml2', $attribs['email'][0]), $e->getMessage());
+            if (method_exists($this, 'assertStringContainsString')) {
+                $this->assertStringContainsString(get_string('emailtaken', 'auth_saml2', $attribs['email'][0]), $e->getMessage());
+            } else {
+                $this->assertContains(get_string('emailtaken', 'auth_saml2', $attribs['email'][0]), $e->getMessage());
+            }
         }
 
         // Checking that the event contains the expected values.
@@ -455,7 +467,11 @@ class auth_test extends \advanced_testcase {
             $this->fail('Exception expected');
         } catch (\coding_exception $e) {
             // Validate reason.
-            $this->assertStringContainsString(get_string('flagmessage_default', 'auth_saml2'), $e->getMessage());
+            if (method_exists($this, 'assertStringContainsString')) {
+                $this->assertStringContainsString(get_string('flagmessage_default', 'auth_saml2'), $e->getMessage());
+            } else {
+                $this->assertContains(get_string('flagmessage_default', 'auth_saml2'), $e->getMessage());
+            }
         }
 
         // Checking that the event contains the expected values.
@@ -480,7 +496,11 @@ class auth_test extends \advanced_testcase {
             $this->fail('Exception expected');
         } catch (\coding_exception $e) {
             // Validate reason.
-            $this->assertStringContainsString(get_string('nouser', 'auth_saml2', $attribs['uid'][0]), $e->getMessage());
+            if (method_exists($this, 'assertStringContainsString')) {
+                $this->assertStringContainsString(get_string('nouser', 'auth_saml2', $attribs['uid'][0]), $e->getMessage());
+            } else {
+                $this->assertContains(get_string('nouser', 'auth_saml2', $attribs['uid'][0]), $e->getMessage());
+            }
         }
 
         // Checking that the event contains the expected values.
@@ -505,7 +525,11 @@ class auth_test extends \advanced_testcase {
             $this->fail('Exception expected');
         } catch (\coding_exception $e) {
             // Validate reason.
-            $this->assertStringContainsString(get_string('suspendeduser', 'auth_saml2', $attribs['uid'][0]), $e->getMessage());
+            if (method_exists($this, 'assertStringContainsString')) {
+                $this->assertStringContainsString(get_string('suspendeduser', 'auth_saml2', $attribs['uid'][0]), $e->getMessage());
+            } else {
+                $this->assertContains(get_string('suspendeduser', 'auth_saml2', $attribs['uid'][0]), $e->getMessage());
+            }
         }
 
         // Checking that the event contains the expected values.
@@ -531,7 +555,11 @@ class auth_test extends \advanced_testcase {
             $this->fail('Exception expected');
         } catch (\coding_exception $e) {
             // Validate reason.
-            $this->assertStringContainsString(get_string('wrongauth', 'auth_saml2', $attribs['uid'][0]), $e->getMessage());
+            if (method_exists($this, 'assertStringContainsString')) {
+                $this->assertStringContainsString(get_string('wrongauth', 'auth_saml2', $attribs['uid'][0]), $e->getMessage());
+            } else {
+                $this->assertContains(get_string('wrongauth', 'auth_saml2', $attribs['uid'][0]), $e->getMessage());
+            }
         }
 
         // Checking that the event contains the expected values.
@@ -560,7 +588,11 @@ class auth_test extends \advanced_testcase {
             $msg = get_string('anyauthotherdisabled', 'auth_saml2', [
                 'username' => $attribs['uid'][0], 'auth' => 'shibboleth',
             ]);
-            $this->assertStringContainsString($msg, $e->getMessage());
+            if (method_exists($this, 'assertStringContainsString')) {
+                $this->assertStringContainsString($msg, $e->getMessage());
+            } else {
+                $this->assertContains($msg, $e->getMessage());
+            }
         }
 
         // Checking that the event contains the expected values.

--- a/tests/metadata_fetcher_test.php
+++ b/tests/metadata_fetcher_test.php
@@ -45,6 +45,13 @@ class auth_saml2_metadata_fetcher_testcase extends advanced_testcase {
         }
     }
 
+    /**
+     * Tear down after every test.
+     */
+    protected function tearDown(): void {
+        $this->prophet = null; // Required for Totara 12+ support (see issue #578).
+    }
+
     public function test_fetch_metadata_404() {
         $url = $this->getExternalTestFileUrl('/test404.xml');
         $fetcher = new metadata_fetcher();

--- a/tests/metadata_refresh_test.php
+++ b/tests/metadata_refresh_test.php
@@ -47,6 +47,13 @@ class auth_saml2_metadata_refresh_testcase extends advanced_testcase {
         $this->resetAfterTest(true);
     }
 
+    /**
+     * Tear down after every test.
+     */
+    protected function tearDown(): void {
+        $this->prophet = null;  // Required for Totara 12+ support (see issue #578).
+    }
+
     public function test_metadata_refresh_disabled() {
         set_config('idpmetadatarefresh', 0, 'auth_saml2');
         set_config('idpmetadata', 'http://somefakeidpurl.local', 'auth_saml2');

--- a/tests/simplesamlphp_upgrade_test.php
+++ b/tests/simplesamlphp_upgrade_test.php
@@ -49,13 +49,14 @@ class auth_saml2_simplesamlphp_upgrade_testcase extends advanced_testcase {
      * Test to ensure that PHPMailer are removed from autoloaded files.
      */
     public function test_remove_phpmailer_from_autoloaded_files() {
+        global $CFG;
         $this->resetAfterTest();
 
         $filenames = [
-            "auth/saml2/.extlib/simplesamlphp/vendor/composer/autoload_psr4.php",
-            "auth/saml2/.extlib/simplesamlphp/vendor/composer/autoload_static.php",
-            "auth/saml2/.extlib/simplesamlphp/vendor/composer/installed.json",
-            "auth/saml2/.extlib/simplesamlphp/vendor/phpmailer/phpmailer/composer.json",
+            $CFG->dirroot."/auth/saml2/.extlib/simplesamlphp/vendor/composer/autoload_psr4.php",
+            $CFG->dirroot."/auth/saml2/.extlib/simplesamlphp/vendor/composer/autoload_static.php",
+            $CFG->dirroot."/auth/saml2/.extlib/simplesamlphp/vendor/composer/installed.json",
+            $CFG->dirroot."/auth/saml2/.extlib/simplesamlphp/vendor/phpmailer/phpmailer/composer.json",
         ];
 
         foreach ($filenames as $filename) {


### PR DESCRIPTION
Relates to issue #644 - fixes some unit test issues when using the 3.9 branch on T12 and higher.

This PR takes care of assertStringContainsString backwards compatiblity (using the same method as some of the other existing saml testing code), fixes a unit test failure where the autoloading classes paths are not specific enough (totara has that extra directory for wwwroot code) and ports #578 from the 3.5 stable branch into the 3.9 stable branch - it doesn't appear to affect 3.9 and higher tests.