### PR TITLE
When attempt IdP logout is off delete the SP cookie #499

### DIFF
--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021062900;    // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2021062900;    // Match release exactly to version.
+$plugin->version   = 2021062901;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2021062901;    // Match release exactly to version.
 $plugin->requires  = 2017051509;    // Requires PHP 7, 2017051509 = T12. M3.3
                                     // Strictly we require either Moodle 3.5 OR
                                     // we require Totara 3.3, but the version number


### PR DESCRIPTION
#499

To test, before and after:

1) set auth_saml2 | attemptsignout to be no
2) login as a student
3) logout of moodle
4) confirm you are still logged into the IdP
5) on the moodle login page click on the idp again
6) confirm that you are redirected through the idp to re-check the session is correct (before path this didn't happen and you were logged straight back in)
