### PR TITLE
Support old versions of php unit (T12 support)

### DIFF
--- a/tests/auth_test.php
+++ b/tests/auth_test.php
@@ -229,14 +229,25 @@ class auth_test extends \advanced_testcase {
         $auth = get_auth_plugin('saml2');
         $this->assertCount(2, $auth->metadataentities);
 
-        // Check entity name.
-        $this->assertEqualsCanonicalizing(['Login 1', $entity1->defaultname], array_column($auth->metadataentities, 'name'));
-
-        // Encoded entityid present as an attribute as well as the key.
-        $this->assertEqualsCanonicalizing([md5($entity1->entityid), md5($entity3->entityid)],
-            array_column($auth->metadataentities, 'md5entityid'));
-        $this->assertEqualsCanonicalizing([md5($entity1->entityid), md5($entity3->entityid)],
-            array_keys($auth->metadataentities));
+        // Backwards compatibility with older PHPUnit - use old Canonicalizing method.
+        if (method_exists($this, 'assertEqualsCanonicalizing')) {
+            // Check entity name.
+            $this->assertEqualsCanonicalizing(['Login 1', $entity1->defaultname], array_column($auth->metadataentities, 'name'));
+            // Encoded entityid present as an attribute as well as the key.
+            $this->assertEqualsCanonicalizing([md5($entity1->entityid), md5($entity3->entityid)],
+                array_column($auth->metadataentities, 'md5entityid'));
+            $this->assertEqualsCanonicalizing([md5($entity1->entityid), md5($entity3->entityid)],
+                array_keys($auth->metadataentities));
+        } else {
+            // Check entity name.
+            $this->assertEquals(['Login 1', $entity1->defaultname],
+                array_column($auth->metadataentities, 'name'), '', 0, 10, true);
+            // Encoded entityid present as an attribute as well as the key.
+            $this->assertEquals([md5($entity1->entityid), md5($entity3->entityid)],
+                array_column($auth->metadataentities, 'md5entityid'), '', 0, 10, true);
+            $this->assertEquals([md5($entity1->entityid), md5($entity3->entityid)],
+                array_keys($auth->metadataentities), '', 0, 10, true);
+        }
 
         // Multiidp flag is true.
         $reflector = new \ReflectionClass($auth);
@@ -346,7 +357,13 @@ class auth_test extends \advanced_testcase {
         set_config('idpname', '', 'auth_saml2');
         $auth = get_auth_plugin('saml2');
         $list = $auth->loginpage_idp_list('/');
-        $this->assertEqualsCanonicalizing([$entity1->displayname, $entity2->displayname], array_column($list, 'name'));
+
+        // Backwards compatibility with older PHPUnit - use old Canonicalizing method.
+        if (method_exists($this, 'assertEqualsCanonicalizing')) {
+            $this->assertEqualsCanonicalizing([$entity1->displayname, $entity2->displayname], array_column($list, 'name'));
+        } else {
+            $this->assertEquals([$entity1->displayname, $entity2->displayname], array_column($list, 'name'), '', 0, 10, true);
+        }
 
         // Unset display name for first entity, it will be replaced by entity default name.
         $DB->update_record('auth_saml2_idps', [
@@ -355,7 +372,13 @@ class auth_test extends \advanced_testcase {
         ]);
         $auth = get_auth_plugin('saml2');
         $list = $auth->loginpage_idp_list('/');
-        $this->assertEqualsCanonicalizing([$entity1->defaultname, $entity2->displayname], array_column($list, 'name'));
+
+        // Backwards compatibility with older PHPUnit - use old Canonicalizing method.
+        if (method_exists($this, 'assertEqualsCanonicalizing')) {
+            $this->assertEqualsCanonicalizing([$entity1->defaultname, $entity2->displayname], array_column($list, 'name'));
+        } else {
+            $this->assertEquals([$entity1->defaultname, $entity2->displayname], array_column($list, 'name'), '', 0, 10, true);
+        }
 
         // Unset default name for first entity, it will be replaced by default with hostname mentioned.
         $DB->update_record('auth_saml2_idps', [
@@ -365,7 +388,13 @@ class auth_test extends \advanced_testcase {
         $idpname1 = get_string('idpnamedefault_varaible', 'auth_saml2', parse_url($entity1->entityid, PHP_URL_HOST));
         $auth = get_auth_plugin('saml2');
         $list = $auth->loginpage_idp_list('/');
-        $this->assertEqualsCanonicalizing([$idpname1, $entity2->displayname], array_column($list, 'name'));
+
+        // Backwards compatibility with older PHPUnit - use old Canonicalizing method.
+        if (method_exists($this, 'assertEqualsCanonicalizing')) {
+            $this->assertEqualsCanonicalizing([$idpname1, $entity2->displayname], array_column($list, 'name'));
+        } else {
+            $this->assertEquals([$idpname1, $entity2->displayname], array_column($list, 'name'), '', 0, 10, true);
+        }
 
         // Deactivate first entity.
         $DB->update_record('auth_saml2_idps', [

--- a/tests/generator_test.php
+++ b/tests/generator_test.php
@@ -79,19 +79,34 @@ class generator_testcase extends \advanced_testcase {
         $this->get_generator()->create_idp_entity();
         $auth = get_auth_plugin('saml2');
         $this->assertCount(2, $auth->metadataentities);
-        $this->assertEqualsCanonicalizing(['Test IdP 1', 'Test IdP 2'], array_column($auth->metadataentities, 'name'));
+        // Backwards compatibility with older PHPUnit - use old Canonicalizing method.
+        if (method_exists($this, 'assertEqualsCanonicalizing')) {
+            $this->assertEqualsCanonicalizing(['Test IdP 1', 'Test IdP 2'], array_column($auth->metadataentities, 'name'));
+        } else {
+            $this->assertEquals(['Test IdP 1', 'Test IdP 2'], array_column($auth->metadataentities, 'name'), '', 0, 10, true);
+        }
 
         // Create non-active entity, it should not be added to metadataentities.
         $this->get_generator()->create_idp_entity(['activeidp' => 0]);
         $auth = get_auth_plugin('saml2');
         $this->assertCount(2, $auth->metadataentities);
-        $this->assertEqualsCanonicalizing(['Test IdP 1', 'Test IdP 2'], array_column($auth->metadataentities, 'name'));
+        // Backwards compatibility with older PHPUnit - use old Canonicalizing method.
+        if (method_exists($this, 'assertEqualsCanonicalizing')) {
+            $this->assertEqualsCanonicalizing(['Test IdP 1', 'Test IdP 2'], array_column($auth->metadataentities, 'name'));
+        } else {
+            $this->assertEquals(['Test IdP 1', 'Test IdP 2'], array_column($auth->metadataentities, 'name'), '', 0, 10, true);
+        }
 
         // Create custom named entity.
         $this->get_generator()->create_idp_entity(['defaultname' => 'Generator']);
         $auth = get_auth_plugin('saml2');
         $this->assertCount(3, $auth->metadataentities);
-        $this->assertEqualsCanonicalizing(['Test IdP 1', 'Test IdP 2', 'Generator'], array_column($auth->metadataentities, 'name'));
+        // Backwards compatibility with older PHPUnit - use old Canonicalizing method.
+        if (method_exists($this, 'assertEqualsCanonicalizing')) {
+            $this->assertEqualsCanonicalizing(['Test IdP 1', 'Test IdP 2', 'Generator'], array_column($auth->metadataentities, 'name'));
+        } else {
+            $this->assertEquals(['Test IdP 1', 'Test IdP 2', 'Generator'], array_column($auth->metadataentities, 'name'), '', 0, 10, true);
+        }
     }
 
     /**


### PR DESCRIPTION
follow up with #644 - allow PHP unit to work on T12 branches.