### PR TITLE
Re-Add check for Totara 12 compatibility

### DIFF
--- a/classes/auth.php
+++ b/classes/auth.php
@@ -625,8 +625,11 @@ class auth extends \auth_plugin_base {
         }
 
         // Moodle Workplace - Check IdP's tenant availability, for new user pre-allocate to tenant.
-        component_class_callback('\tool_tenant\local\auth\saml2\manager', 'complete_login_hook',
-            [$SESSION->saml2idp ?? '', $uid, $user]);
+        // Check if function exists required for Totara 12 compatibility.
+        if (class_exists(\tool_tenant\local\auth\saml2\manager::class)) {
+            component_class_callback('\tool_tenant\local\auth\saml2\manager', 'complete_login_hook',
+                [$SESSION->saml2idp ?? '', $uid, $user]);
+        }
 
         $newuser = false;
         if (!$user) {


### PR DESCRIPTION
If function doesn't exist, skip calls to component_class_callback so unit tests can pass with T12.

This code was submitted in this PR https://github.com/catalyst/moodle-auth_saml2/pull/655 and merged but is now missing from the codebase. If absent, it breaks phpunit tests on Totara 12.