### PR TITLE
Fix behat and unit tests

### DIFF
--- a/classes/user_extractor.php
+++ b/classes/user_extractor.php
@@ -55,11 +55,8 @@ class user_extractor {
 
             $joins = " LEFT JOIN {user_info_field} f ON f.shortname = :fieldname ";
             $joins .= " LEFT JOIN {user_info_data} d ON d.fieldid = f.id AND d.userid = u.id ";
-            if ($insensitive) {
-                $fieldsql = " AND LOWER(d.data) = LOWER(:fieldvalue)";
-            } else {
-                $fieldsql = " AND d.data = :fieldvalue";
-            }
+
+            $fieldsql = " AND ". $DB->sql_equal('d.data', ':fieldvalue', !$insensitive);
             $params['fieldname'] = $fieldname;
             $params['fieldvalue'] = $fieldvalue;
             $params['mnethostid'] = $CFG->mnet_localhost_id;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -376,5 +376,17 @@ function xmldb_auth_saml2_upgrade($oldversion) {
         // Saml2 savepoint reached.
     }
 
+    if ($oldversion < 2022031503) {
+        if (in_array($CFG->dbtype, ['mysqli', 'mariadb'])) {
+            $tolower = get_config('auth_saml2', 'tolower');
+            if (empty($tolower) || $tolower == auth_saml2\admin\saml2_settings::OPTION_TOLOWER_EXACT) {
+                // Previous versions of the code meant that mariadb operated in a case-insensitive manner set to prevent issues.
+                set_config('tolower', auth_saml2\admin\saml2_settings::OPTION_TOLOWER_CASE_INSENSITIVE, 'auth_saml2');
+            }
+        }
+
+        upgrade_plugin_savepoint(true, 2022031503, 'auth', 'saml2');
+    }
+
     return true;
 }

--- a/tests/behat/autologin.feature
+++ b/tests/behat/autologin.feature
@@ -23,7 +23,7 @@ Feature: Automatically log in
     And the mock SAML IdP allows passive login with the following attributes: # auth_saml2
       | uid | student1 |
     Then I should see "Course 1"
-    And I should see "Eigh Person" in the ".userbutton" "css_element"
+    And I should see "Eigh Person"
 
     # Future requests should not contact the IdP (obviously, because logged in).
     When I follow "Course 1"
@@ -45,7 +45,7 @@ Feature: Automatically log in
 
     # Future requests should not contact the IdP.
     When I follow "Course 1"
-    Then I should see "Forgotten your username or password?"
+    Then I should see "Log in"
 
   Scenario: Autologin on cookie change
     Given the authentication plugin saml2 is enabled # auth_saml2
@@ -83,16 +83,16 @@ Feature: Automatically log in
     And I am on site homepage
     And the mock SAML IdP allows passive login with the following attributes: # auth_saml2
       | uid | student1 |
-    Then I should see "Eigh Person" in the ".userbutton" "css_element"
+    Then I should see "Eigh Person"
 
     # No login attempt on another page request, even if the cookie changes
     # or is removed, because the user is logged in now.
     When the cookie "frog" is set to "Kermit" # auth_saml2
     And I am on site homepage
-    Then I should see "Eigh Person" in the ".userbutton" "css_element"
+    Then I should see "Eigh Person"
     When the cookie "frog" is removed # auth_saml2
     And I am on site homepage
-    Then I should see "Eigh Person" in the ".userbutton" "css_element"
+    Then I should see "Eigh Person"
 
   Scenario: Autologin to activity page within a course
     Given the authentication plugin saml2 is enabled # auth_saml2
@@ -117,7 +117,7 @@ Feature: Automatically log in
     And the mock SAML IdP allows passive login with the following attributes: # auth_saml2
       | uid | student1 |
     Then I should see "Test page description"
-    And I should see "Eigh Person" in the ".userbutton" "css_element"
+    And I should see "Eigh Person"
 
   Scenario: Situations which are excluded from autologin
     Given the authentication plugin saml2 is enabled # auth_saml2
@@ -153,11 +153,11 @@ Feature: Automatically log in
 
     # Set up the homepage so that we can test POST requests
     When I log in as "admin"
-    And I follow "Site home"
+    And I am on site homepage
     And I navigate to "Edit settings" in current page administration
     And I set the field "summary" to "<form method='post' action='.'><div><button type='submit'>PostTest</button></div></form>"
     And I press "Save changes"
-    And I follow "Site home"
+    And I am on site homepage
     And I navigate to "Turn editing on" in current page administration
     And I add the "Course/site summary" block
     And I click on "Log out" "link" in the "#page-footer" "css_element"

--- a/tests/behat/autologin.feature
+++ b/tests/behat/autologin.feature
@@ -129,6 +129,9 @@ Feature: Automatically log in
       | auth            | saml2 |            |
       | autologin       | 2     | auth_saml2 |
       | autologincookie | frog  | auth_saml2 |
+    And the following "blocks" exist:
+      | blockname     | contextlevel | reference | pagetypepattern | defaultregion |
+      | html | System       | 1         | site-index       | side-post     |
     And I am on site homepage
 
     # With this config, changing the cookie would usually result in an autologin attempt.
@@ -154,12 +157,10 @@ Feature: Automatically log in
     # Set up the homepage so that we can test POST requests
     When I log in as "admin"
     And I am on site homepage
-    And I navigate to "Edit settings" in current page administration
-    And I set the field "summary" to "<form method='post' action='.'><div><button type='submit'>PostTest</button></div></form>"
+    And I turn editing mode on
+    And I configure the "block_html" block
+    And I set the field "Content" to "<form method='post' action='.'><div><button type='submit'>PostTest</button></div></form>"
     And I press "Save changes"
-    And I am on site homepage
-    And I navigate to "Turn editing on" in current page administration
-    And I add the "Course/site summary" block
     And I click on "Log out" "link" in the "#page-footer" "css_element"
 
     # Situation 4: Autologin does not run on POST requests.

--- a/tests/user_extractor_test.php
+++ b/tests/user_extractor_test.php
@@ -156,6 +156,7 @@ class auth_saml2_user_extractor_test extends advanced_testcase {
      * Tests for case insensitive match.
      */
     public function test_get_user_case_insensitive() {
+        global $CFG;
         $this->resetAfterTest();
 
         // Arrange data

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022030300;    // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2022030300;    // Match release exactly to version.
+$plugin->version   = 2022031503;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2022031503;    // Match release exactly to version.
 $plugin->requires  = 2017051509;    // Requires PHP 7, 2017051509 = T12. M3.3
                                     // Strictly we require either Moodle 3.5 OR
                                     // we require Totara 3.3, but the version number


### PR DESCRIPTION
@dmitriim do you want to review the changes to teh user_extrator class to make it case sensitive for Mariadb based sites?

also - do we need to be aware of this changing existing behaviour for mariadb based sites who will have been getting case insensitive results even though the default setting for sensistivity is set to an exact match?