### PR TITLE
When username field is updated, be consistent about how we set it.

### DIFF
--- a/classes/auth.php
+++ b/classes/auth.php
@@ -925,9 +925,12 @@ class auth extends \auth_plugin_base {
                                         continue;
                                     }
                                 }
-
-                                // Custom profile fields have the prefix profile_field_ and will be saved as profile field data.
-                                $user->$field = $attributes[$attr][0];
+                                if ($field == 'username') {
+                                    $user->$field = strtolower($attributes[$attr][0]);
+                                } else {
+                                    // Custom profile fields have the prefix profile_field_ and will be saved as profile field data.
+                                    $user->$field = $attributes[$attr][0];
+                                }
                                 $update = true;
                             }
                         }

--- a/tests/auth_test.php
+++ b/tests/auth_test.php
@@ -1358,6 +1358,32 @@ class auth_test extends \advanced_testcase {
     }
 
     /**
+     * Tests we can update username with invalid case from any SAML attribute on user creation.
+     */
+    public function test_update_user_profile_fields_updates_username_on_creation_case_insensitive(): void {
+        global $CFG;
+        require_once($CFG->dirroot . '/user/profile/lib.php');
+
+        $auth = get_auth_plugin('saml2');
+        $user = $this->getDataGenerator()->create_user();
+
+        $expected = 'updated_username';
+        $uppercaseusername = strtoupper($expected);
+        $this->assertNotEquals($expected, $user->username);
+
+        set_config("field_map_username", 'field', 'auth_saml2');
+        set_config("field_updatelocal_username", 'onlogin', 'auth_saml2');
+        set_config("field_lock_username", 'locked', 'auth_saml2');
+
+        $attributes = [
+            'field' => [$uppercaseusername]
+        ];
+
+        $this->assertTrue($auth->update_user_profile_fields($user, $attributes, true));
+        $this->assertEquals($expected, $user->username);
+    }
+
+    /**
      * Tests we can't update username from any SAML attribute once a user already created.
      */
     public function test_update_user_profile_fields_does_not_update_username_on_update(): void {


### PR DESCRIPTION
when the username is updated, we should make sure it is set to lower case in the same way we do when creating the user.