### PR TITLE
Fix deprecated twig class reference

### DIFF
--- a/tests/autoloader_test.php
+++ b/tests/autoloader_test.php
@@ -38,7 +38,7 @@ class auth_saml2_autoloader_test extends advanced_testcase {
             \SAML2\Utils::class,
             \SimpleSAML\Configuration::class,
             \RobRichards\XMLSecLibs\XMLSecEnc::class,
-            Twig_Loader_Filesystem::class,
+            Twig\Loader\FilesystemLoader::class,
         ];
         foreach ($classes as $class) {
             $found = class_exists($class) || interface_exists($class);


### PR DESCRIPTION
Closes #711 

Saml2 test suite passes, unsure of how else to test this change. Should be a non-issue as its referring to the same class anyway.



