### PR TITLE
MBS-6571: Fix issue with case insensitive search on usernames

### DIFF
--- a/classes/admin/saml2_settings.php
+++ b/classes/admin/saml2_settings.php
@@ -55,4 +55,6 @@ abstract class saml2_settings {
     const OPTION_TOLOWER_LOWER_CASE = 1;
 
     const OPTION_TOLOWER_CASE_INSENSITIVE = 2;
+
+    const OPTION_TOLOWER_CASE_AND_ACCENT_INSENSITIVE = 3;
 }

--- a/classes/auth.php
+++ b/classes/auth.php
@@ -614,6 +614,7 @@ class auth extends \auth_plugin_base {
         $user = false;
         foreach ($attributes[$attr] as $uid) {
             $insensitive = false;
+            $accentsensitive = true;
             if ($this->config->tolower == saml2_settings::OPTION_TOLOWER_LOWER_CASE) {
                 $this->log(__FUNCTION__ . " to lowercase for $uid");
                 $uid = strtolower($uid);
@@ -622,7 +623,12 @@ class auth extends \auth_plugin_base {
                 $this->log(__FUNCTION__ . " case insensitive compare for $uid");
                 $insensitive = true;
             }
-            if ($user = user_extractor::get_user($this->config->mdlattr, $uid, $insensitive)) {
+            if ($this->config->tolower == saml2_settings::OPTION_TOLOWER_CASE_AND_ACCENT_INSENSITIVE) {
+                $this->log(__FUNCTION__ . " case and accent insensitive compare for $uid");
+                $insensitive = true;
+                $accentsensitive = false;
+            }
+            if ($user = user_extractor::get_user($this->config->mdlattr, $uid, $insensitive, $accentsensitive)) {
                 // We found a user.
                 break;
             }

--- a/classes/user_extractor.php
+++ b/classes/user_extractor.php
@@ -41,6 +41,7 @@ class user_extractor {
      * @param string $fieldname Field name to search by.
      * @param string $fieldvalue Field value to search by.
      * @param bool $insensitive Whether to use case insensitive match.
+     * @param bool $accentsensitive Whether to use accent sensitive match.
      *
      * @return mixed False, or A {@link $USER} object.
      */

--- a/classes/user_extractor.php
+++ b/classes/user_extractor.php
@@ -44,7 +44,12 @@ class user_extractor {
      *
      * @return mixed False, or A {@link $USER} object.
      */
-    public static function get_user(string $fieldname, string $fieldvalue, bool $insensitive = false) {
+    public static function get_user(
+        string $fieldname,
+        string $fieldvalue,
+        bool $insensitive = false,
+        bool $accentsensitive = true
+    ) {
         global $DB, $CFG;
 
         $user = false;
@@ -59,14 +64,14 @@ class user_extractor {
             $joins = " LEFT JOIN {user_info_field} f ON f.shortname = :fieldname ";
             $joins .= " LEFT JOIN {user_info_data} d ON d.fieldid = f.id AND d.userid = u.id ";
 
-            $fieldsql = " AND ". $DB->sql_equal('d.data', ':fieldvalue', !$insensitive);
+            $fieldsql = " AND " . $DB->sql_equal('d.data', ':fieldvalue', !$insensitive, $accentsensitive);
             $params['fieldname'] = $fieldname;
 
         } else {
             // Check if requested field exists, required for Totara compatibility.
             $fields = array_merge(\core_user::AUTHSYNCFIELDS, ['id', 'username']);
             if (in_array($fieldname, $fields)) {
-                $fieldsql = " AND ". $DB->sql_equal('u.' . $fieldname, ':fieldvalue', !$insensitive);
+                $fieldsql = " AND " . $DB->sql_equal('u.' . $fieldname, ':fieldvalue', !$insensitive, $accentsensitive);
                 $params['fieldname'] = $fieldname;
             }
         }

--- a/lang/en/auth_saml2.php
+++ b/lang/en/auth_saml2.php
@@ -187,6 +187,7 @@ $string['testdebuggingdisabled'] = 'To use this testing page SAML debugging must
 $string['tolower'] = 'Case matching';
 $string['tolower:exact'] = 'Exact';
 $string['tolower:lowercase'] = 'Lower case';
+$string['tolower:caseandaccentinsensitive'] = 'Case and accent insensitive';
 $string['tolower:caseinsensitive'] = 'Case insensitive';
 $string['tolower_help'] = '
 <p>Exact: match is case sensitive (default).</p>

--- a/settings.php
+++ b/settings.php
@@ -292,6 +292,7 @@ if ($ADMIN->fulltree) {
         saml2_settings::OPTION_TOLOWER_EXACT => get_string('tolower:exact', 'auth_saml2'),
         saml2_settings::OPTION_TOLOWER_LOWER_CASE => get_string('tolower:lowercase', 'auth_saml2'),
         saml2_settings::OPTION_TOLOWER_CASE_INSENSITIVE => get_string('tolower:caseinsensitive', 'auth_saml2'),
+        saml2_settings::OPTION_TOLOWER_CASE_AND_ACCENT_INSENSITIVE => get_string('tolower:caseandaccentinsensitive', 'auth_saml2'),
     ];
     $settings->add(new admin_setting_configselect(
             'auth_saml2/tolower',

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022071800;    // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2022071800;    // Match release exactly to version.
+$plugin->version   = 2022081800;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2022081800;    // Match release exactly to version.
 $plugin->requires  = 2017051509;    // Requires PHP 7, 2017051509 = T12. M3.3
                                     // Strictly we require either Moodle 3.5 OR
                                     // we require Totara 3.3, but the version number
@@ -33,4 +33,3 @@ $plugin->requires  = 2017051509;    // Requires PHP 7, 2017051509 = T12. M3.3
 $plugin->component = 'auth_saml2';  // Full name of the plugin (used for diagnostics).
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->supported = [39, 400];     // A range of branch numbers of supported moodle versions.
-


### PR DESCRIPTION
We have observed in load tests that the newly introduced case sensitive search by username is about a factor of 150 slower than the caseinsensitive search. 
In our opinion, it is not good to hardcode the option casesensitive or not. Therefore we introduced a config parameter to set this option via config.php.