### PR TITLE
Fixes the error 'Your email wasn't updated' when idpattr

### DIFF
--- a/classes/auth.php
+++ b/classes/auth.php
@@ -714,6 +714,7 @@ class auth extends \auth_plugin_base {
                 $user->mnethostid = $CFG->mnet_localhost_id;
 
                 $user->id = \user_create_user($user, true, true);
+                $newuser = true;
                 // Store any custom profile fields.
                 profile_save_data($user);
                 // Make sure all user data is fetched.
@@ -776,7 +777,7 @@ class auth extends \auth_plugin_base {
 
         // Do we need to update any user fields? Unlike ldap, we can only do
         // this now. We cannot query the IdP at any time.
-        $this->update_user_profile_fields($user, $attributes, false);
+        $this->update_user_profile_fields($user, $attributes, $newuser);
 
         // If admin has been set for this IdP we make the user an admin.
         if (!empty($SESSION->saml2idp) && $this->metadataentities[$SESSION->saml2idp]->adminidp) {

--- a/tests/auth_test.php
+++ b/tests/auth_test.php
@@ -672,9 +672,12 @@ class auth_saml2_test extends \advanced_testcase {
 
         // Checking that the events contain the expected values.
         $events = $sink->get_events();
-        $this->assertCount(2, $events);
+        $this->assertCount(3, $events);
         $event = array_pop($events);
         $this->assertInstanceOf('\core\event\user_loggedin', $event);
+        $this->assertEquals($USER->id, $event->get_data()['objectid']);
+        $event = array_pop($events);
+        $this->assertInstanceOf('\core\event\user_updated', $event);
         $this->assertEquals($USER->id, $event->get_data()['objectid']);
         $event = array_pop($events);
         $this->assertInstanceOf('\core\event\user_created', $event);


### PR DESCRIPTION
This fixes the reported https://github.com/catalyst/moodle-auth_saml2/issues/728
saml2 settings used:

field_updatelocal_email: on every login
idpattr: email
mdlattr: email address
autocreate: yes
field_map_username: email

I have tested this on a Moodle 3.9 site. 
Regards,

Sumaiya