### PR TITLE
fix random notice when autocreating users

### DIFF
--- a/classes/auth.php
+++ b/classes/auth.php
@@ -960,7 +960,7 @@ class auth extends \auth_plugin_base {
                                 // If can't have accounts with the same emails, check if email is taken before update a new user.
                                 if ($field == 'email' && empty($CFG->allowaccountssameemail)) {
                                     $email = $attributes[$attr][0];
-                                    if ($this->is_email_taken($email, $user->username)) {
+                                    if ($this->is_email_taken($email, $user->username ?? null)) {
                                         $this->log(__FUNCTION__ .
                                             " user '$user->username' email can't be updated as '$email' is taken");
                                         // Warn user that we are not able to update his email.


### PR DESCRIPTION
Sometimes when autocreating users the method \auth_saml2\auth::update_user_record_from_attribute_map() may first try to validate email before adding username property to empty $user object resulting in "Notice: Undefined property: stdClass::$username in [dirroot]/auth/saml2/classes/auth.php on line 963".

This is annoying because it happens for me repeatedly in my behat tests for SAML2 support in our multi-tenancy code.