### PR TITLE
Fix PHP 8.1 warning related to null whitelist

### DIFF
--- a/classes/auth.php
+++ b/classes/auth.php
@@ -862,7 +862,7 @@ class auth extends \auth_plugin_base {
      */
     protected function check_whitelisted_ip_redirect() {
         foreach ($this->metadataentities as $idpentity) {
-            if (\core\ip_utils::is_ip_in_subnet_list(getremoteaddr(), $idpentity->whitelist)) {
+            if (\core\ip_utils::is_ip_in_subnet_list(getremoteaddr(), $idpentity->whitelist ?? '')) {
                 return $idpentity->md5entityid;
             }
         }


### PR DESCRIPTION
If an entry in auth_saml2_idps is created by the admin settings screen (via the class setting_idpmetadata.php, line 181) then the field 'whitelist' will be null. (If you later edit it using the auth/saml2/availableidps.php script then it will probably be set to blank.)

When the field is null, it causes a warning in PHP 8.1 because the function check_whitelisted_ip_redirect calls core function is_ip_in_subnet_list with parameter 2 null. It then passes the null to core function 'explode' parameter 2, which now causes this warning:

Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /var/www/html/moodle/lib/classess/ip_utils.php on line 237

Since the code worked before, it should be fine to pass empty string instead.