### PR TITLE
Use iso country code in xml:lang attribute for metadata

### DIFF
--- a/config/authsources.php
+++ b/config/authsources.php
@@ -56,7 +56,8 @@ foreach (explode(PHP_EOL, $saml2auth->config->requestedattributes) as $attr) {
     }
     $attributes[] = $attr;
 }
-
+// Moodle language code does not always map to the iso code, which is preferable for xml:lang attributes.
+$lang = get_string('iso6391', 'core_langconfig');
 $config[$saml2auth->spname] = [
     'saml:SP',
     'entityID' => !empty($saml2auth->config->spentityid) ? $saml2auth->config->spentityid : $defaultspentityid,
@@ -64,13 +65,13 @@ $config[$saml2auth->spname] = [
     'idp' => empty($CFG->auth_saml2_disco_url) ? $idpentityid : null,
     'NameIDPolicy' => $saml2auth->config->nameidpolicy,
     'OrganizationName' => array(
-        $CFG->lang => $SITE->shortname,
+        $lang => $SITE->shortname,
     ),
     'OrganizationDisplayName' => array(
-        $CFG->lang => $SITE->fullname,
+        $lang => $SITE->fullname,
     ),
     'OrganizationURL' => array(
-        $CFG->lang => $baseurl,
+        $lang => $baseurl,
     ),
     'privatekey' => $saml2auth->spname . '.pem',
     'privatekey_pass' => get_config('auth_saml2', 'privatekeypass'),
@@ -81,7 +82,7 @@ $config[$saml2auth->spname] = [
     'WantAssertionsSigned' => $saml2auth->config->wantassertionssigned == 1,
 
     'name' => [
-        $CFG->lang => $SITE->fullname,
+        $lang => $SITE->fullname,
     ],
     'attributes' => $attributes,
     'attributes.required' => $attributesrequired,


### PR DESCRIPTION
If you're using a custom Moodle translation pack, especially one of the odd ones like the pirate translation pack, some IDP's appear to refuse to parse the metadata file because  en_arr or similar are not valid xml:lang attributes.

This uses the iso6391 code defined for each language instead, which hopefully will have wider support.