### PR TITLE
PHP 8.2 Creation of dynamic property warnings #781

### DIFF
--- a/classes/admin/setting_button.php
+++ b/classes/admin/setting_button.php
@@ -38,6 +38,11 @@ require_once($CFG->libdir . '/moodlelib.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class setting_button extends admin_setting_heading {
+    /** @var string Button label */
+    protected $label;
+    /** @var string Button href */
+    protected $href;
+
     /**
      * A button element
      *

--- a/classes/auth.php
+++ b/classes/auth.php
@@ -64,6 +64,27 @@ class auth extends \auth_plugin_base {
     private $defaultidp;
 
     /**
+     * @var string SP name
+     */
+    public $spname;
+
+    /**
+     * @var string Contents of certificate .pem file
+     */
+    public $certpem;
+
+    /**
+     * @var string Contents of certificate .crt file
+     */
+    public $certcrt;
+
+    /**
+     * @var idp_data[] List of metadata for IdPs
+     */
+    public $metadatalist;
+
+
+    /**
      * @var array $defaults The config defaults
      */
     public $defaults = [


### PR DESCRIPTION
This branch fixes the dynamic property warnings listed in #781 (it's possible there might be others, we have not been running it very much yet).

Note: I tried to make it compatible with supported PHP versions, so the new field definitions don't have types except in phpdoc. The fields in auth.php needed to be public, otherwise tests fail.