### PR TITLE
Implement before_http_headers hook callback.

### DIFF
--- a/classes/local/hooks/output/before_http_headers.php
+++ b/classes/local/hooks/output/before_http_headers.php
@@ -1,0 +1,36 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace auth_saml2\local\hooks\output;
+
+/**
+ * before_http_headers hook callback for auth_saml2
+ *
+ * @package    auth_saml2
+ * @copyright  2024 Ruslan Kabalin
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class before_http_headers {
+
+    /**
+     * Callback before HTTP headers are sent.
+     *
+     * @param \core\hook\output\before_http_headers $hook
+     */
+    public static function callback(\core\hook\output\before_http_headers $hook): void {
+        \auth_saml2\auto_login::process();
+    }
+}

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -1,0 +1,33 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Hook callbacks for SAML2
+ *
+ * @package    auth_saml2
+ * @copyright  2024 Ruslan Kabalin
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$callbacks = [
+    [
+        'hook' => \core\hook\output\before_http_headers::class,
+        'callback' => [auth_saml2\local\hooks\output\before_http_headers::class, 'callback'],
+        'priority' => 0,
+    ],
+];

--- a/lib.php
+++ b/lib.php
@@ -49,10 +49,9 @@ function auth_saml2_after_config() {
 /**
  * Callback immediately after require_login succeeds.
  *
- * This callback requires Moodle 3.7+. On earlier versions this will not run. It also won't run
- * on pages which don't call require_login, so we use the _before_http_headers() callback too.
- *
- * @since Moodle 3.7
+ * This is an implementation of a legacy callback that will only be called in older Moodle versions.
+ * It will not be called in Moodle 4.4+ that contain the hook core\hook\output\before_http_headers,
+ * instead, the callback auth_saml2\local\hooks\output\before_http_headers::callback will be executed.
  */
 function auth_saml2_after_require_login() {
     \auth_saml2\auto_login::process();


### PR DESCRIPTION
In 4.4 `before_http_headers()` callback has been migrated to hook `core\hook\output\before_http_headers`, keep both for backward compatibility.

Fixes #809