### PR TITLE
Use original string hook callback definition for backwards compat.

### DIFF
--- a/db/hooks.php
+++ b/db/hooks.php
@@ -27,7 +27,7 @@ defined('MOODLE_INTERNAL') || die();
 $callbacks = [
     [
         'hook' => \core\hook\output\before_http_headers::class,
-        'callback' => [auth_saml2\local\hooks\output\before_http_headers::class, 'callback'],
+        'callback' => 'auth_saml2\local\hooks\output\before_http_headers::callback',
         'priority' => 0,
     ],
 ];


### PR DESCRIPTION
See #809 - in order to support this hook from Moodle 4.3 we should use the simple callback format. Support for array callable notation arrived only in 4.4 ([MDL-81180](https://tracker.moodle.org/browse/MDL-81180)).