### PR TITLE
#817: sp/module.php references a file that no longer exists

### DIFF
--- a/classes/auth.php
+++ b/classes/auth.php
@@ -109,7 +109,8 @@ class auth extends \auth_plugin_base {
         'nameidasattrib'     => 0,
         'flagresponsetype'   => saml2_settings::OPTION_FLAGGED_LOGIN_MESSAGE,
         'flagredirecturl'    => '',
-        'flagmessage'        => '' // Set in constructor.
+        'flagmessage'        => '', // Set in constructor.
+        'tempdir'            => '/tmp/simplesaml'
     ];
 
     /**

--- a/config/config.php
+++ b/config/config.php
@@ -49,7 +49,7 @@ $config = array(
     'debug'             => ['saml' => $saml2auth->is_debugging()],
     'logging.level'     => $saml2auth->is_debugging() ? SimpleSAML\Logger::DEBUG : SimpleSAML\Logger::ERR,
     'logging.handler'   => $saml2auth->config->logtofile ? 'file' : 'errorlog',
-    'tempdir'           => '/tmp/simplesaml',
+    'tempdir'           => $saml2auth->config->tempdir,
 
     // SSP has a %srcip token, but instead use $remoteip so Moodle handle's which header to use.
     'logging.format'    => '%date{%b %d %H:%M:%S} ' . $remoteip . ' %process %level %stat[%trackid] %msg',

--- a/config/config.php
+++ b/config/config.php
@@ -49,6 +49,7 @@ $config = array(
     'debug'             => ['saml' => $saml2auth->is_debugging()],
     'logging.level'     => $saml2auth->is_debugging() ? SimpleSAML\Logger::DEBUG : SimpleSAML\Logger::ERR,
     'logging.handler'   => $saml2auth->config->logtofile ? 'file' : 'errorlog',
+    'tempdir'           => '/tmp/simplesaml',
 
     // SSP has a %srcip token, but instead use $remoteip so Moodle handle's which header to use.
     'logging.format'    => '%date{%b %d %H:%M:%S} ' . $remoteip . ' %process %level %stat[%trackid] %msg',

--- a/lang/en/auth_saml2.php
+++ b/lang/en/auth_saml2.php
@@ -176,6 +176,9 @@ $string['spmetadata_help'] = '<a href=\'{$a}\'>View Service Provider Metadata</a
 $string['spmetadatasign_help'] = 'Sign the SP Metadata.';
 $string['spmetadatasign'] = 'SP Metadata signature';
 $string['spmetadata'] = 'SP Metadata';
+$string['tempdirdefault'] = '/tmp/simplesaml';
+$string['tempdir_help'] = 'A directory where SimpleSAMLphp can save temporary files';
+$string['tempdir'] = 'SimpleSAMLphp temporary directory';
 $string['sspversion'] = 'SimpleSAMLphp version';
 $string['stateorprovincename'] = 'State or Province';
 $string['status'] = 'Status';

--- a/settings.php
+++ b/settings.php
@@ -360,6 +360,16 @@ urn:mace:dir:attribute-def:mail *</pre>"]),
         1,
         $yesno));
 
+    // SAMLPHP tempdir
+    $settings->add(new admin_setting_configtext(
+        'auth_saml2/tempdir',
+        get_string('tempdir', 'auth_saml2'),
+        get_string('tempdir_help', 'auth_saml2'),
+        get_string('tempdirdefault', 'auth_saml2'),
+        PARAM_TEXT,
+        50,
+        3));
+
     // SAMLPHP version.
     $authplugin = get_auth_plugin('saml2');
     $settings->add(new setting_textonly(

--- a/sp/module.php
+++ b/sp/module.php
@@ -33,4 +33,4 @@ if (!empty($CFG->sslproxy)) {
     $_SERVER['SERVER_PORT'] = '443';
 }
 
-require($CFG->dirroot.'/auth/saml2/.extlib/simplesamlphp/www/module.php');
+require($CFG->dirroot.'/auth/saml2/.extlib/simplesamlphp/public/module.php');


### PR DESCRIPTION
This is a fix for https://github.com/catalyst/moodle-auth_saml2/issues/817. We have a client that, after updating auth_saml2 to the latest version available on the plugin directory for 4.3, was receiving the following error:
```
Exception - Failed opening required '[dirroot]/auth/saml2/.extlib/simplesamlphp/www/module.php' (include_path='[dirroot]/lib/pear:.:/usr/share/php')
```
The www/module.php file no longer exists in the included version of simplesamlphp, and as discovered by the issue filer, has been replaced by public/module.php. After replacing the reference in sp/module.php, we received a new error:

```
SimpleSAMLphp
Unhandled exception
An unhandled exception was thrown.
If you report this error, please also report this tracking number which makes it possible to locate your session in the logs available to the system administrator:

b2924b4297

Debug information
The debug information below may be of interest to the administrator / help desk:

SimpleSAML\Error\Error: UNHANDLEDEXCEPTION
Backtrace:
1 public/_include.php:28 (SimpleSAML_exception_handler)
0 [builtin] (N/A)
Caused by: SimpleSAML\Assert\AssertionFailedException: .../moodle-4.3/auth/saml2/config/config.php: Could not retrieve the required option 'tempdir'.
...
```
It appeared that the simplesamlphp library was looking for a "tempdir" config setting, which wasn't included in config/config.php. After adding said value, the login flow was working again. We set the value to `/tmp/simplesaml`, but there may be a better default. 
