### PR TITLE
Add setting to restrict noredirect by ip #826

### DIFF
--- a/lang/en/auth_saml2.php
+++ b/lang/en/auth_saml2.php
@@ -151,6 +151,8 @@ $string['nameidasattrib'] = 'Expose NameID as attribute';
 $string['nameidasattrib_help'] = 'The NameID claim will be exposed to SSPHP as an attribute named nameid';
 $string['noattribute'] = 'You have logged in successfully but we could not find your \'{$a}\' attribute to associate you to an account in Moodle.';
 $string['noidpfound'] = 'The IdP \'{$a}\' was not found as a configured IdP.';
+$string['noredirectips'] = 'Restrict noredirect by IP';
+$string['noredirectips_help'] = 'When dual login is turned off and IPs are set, this will restrict the use of ?saml=off and ?noredirect=1 during SAML login to users with matching IP subnets.';
 $string['nouser'] = 'You have logged in successfully as \'{$a}\' but do not have an account in Moodle.';
 $string['nullprivatecert'] = 'Creation of Private Certificate failed.';
 $string['nullpubliccert'] = 'Creation of Public Certificate failed.';

--- a/settings.php
+++ b/settings.php
@@ -246,6 +246,13 @@ if ($ADMIN->fulltree) {
         ));
     }
 
+    $settings->add(new admin_setting_configiplist(
+        'auth_saml2/noredirectips',
+        get_string('noredirectips', 'auth_saml2'),
+        get_string('noredirectips_help', 'auth_saml2'),
+        ''
+    ));
+
     // Auto login.
     $autologinoptions = [
         saml2_settings::OPTION_AUTO_LOGIN_NO => get_string('no'),

--- a/tests/auth_test.php
+++ b/tests/auth_test.php
@@ -788,6 +788,9 @@ class auth_saml2_test extends \advanced_testcase {
             $_GET['multiidp'] = true;
         }
 
+        // Setting an ip to use for testing against different configs.
+        $_SERVER['REMOTE_ADDR'] = '1.2.3.4';
+
         /** @var auth_plugin_saml2 $auth */
         $auth = get_auth_plugin('saml2');
         $result = $auth->should_login_redirect();
@@ -934,6 +937,55 @@ class auth_saml2_test extends \advanced_testcase {
                 ['duallogin' => true],
                 'on', true, false,
                 $midp],
+
+            // Restrict noredirect flags by ip.
+            // IP restrictions for ?saml=off should only take effect when dual is off.
+            "21. dual: y, ips: no match, param: off, multiidp: false, session: false" => [
+                [],
+                ['duallogin' => true, 'noredirectips' => '4.3.2.1'],
+                'off', false, false,
+                false],
+
+            // Ignore ?saml=off when ip restrictions are set and there's no matching ip.
+            "22. dual: n, ips: no match, param: off, multiidp: false, session: false" => [
+                [],
+                ['duallogin' => false, 'noredirectips' => '4.3.2.1'],
+                'off', false, false,
+                true],
+
+            // Allow ?saml=off when ip restrictions are set and there's a matching ip.
+            "23. dual: n, ips: match, param: off, multiidp: false, session: false" => [
+                [],
+                ['duallogin' => false, 'noredirectips' => '1.2.3.4'],
+                'off', false, false,
+                false],
+
+            // Matching ip subsets.
+            "24. dual: n, ips: match subset, param: off, multiidp: false, session: false" => [
+                [],
+                ['duallogin' => false, 'noredirectips' => '1.2'],
+                'off', false, false,
+                false],
+
+            // Multiple lines.
+            "25. dual: n, ips: match line, param: off, multiidp: false, session: false" => [
+                [],
+                ['duallogin' => false, 'noredirectips' => '4.3.2.1' . PHP_EOL . '1.2.3.4'],
+                'off', false, false,
+                false],
+
+            // Confirm this works the same for sessions.
+            "26. dual: n, ips: no match, param: off, multiidp: false, session: true" => [
+                [],
+                ['duallogin' => false, 'noredirectips' => '4.3.2.1'],
+                'off', false, true,
+                true],
+
+            "27. dual: n, ips: match, param: off, multiidp: false, session: true" => [
+                [],
+                ['duallogin' => false, 'noredirectips' => '1.2.3.4'],
+                'off', false, true,
+                false],
         ];
     }
 

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024071101;    // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2024071101;    // Match release exactly to version.
+$plugin->version   = 2024082000;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2024082000;    // Match release exactly to version.
 $plugin->requires  = 2017051509;    // Requires PHP 7, 2017051509 = T12. M3.3
                                     // Strictly we require either Moodle 3.5 OR
                                     // we require Totara 3.3, but the version number


### PR DESCRIPTION
Closes #826 

Adds a new setting that allows admins to restrict the use of ?saml=off and ?noredirect=1 during SAML login to access the backdoor to certain IPs.

For now I've limited this functionality to when dual login is disabled as that's the only time it would be a backdoor. 

Users can still technically reach the backdoor when there's errors - I thought about adding a check there as well, but it's a bit different from how I've described this feature.