### PR TITLE
PHP 8.2 Creation of dynamic property warnings

### DIFF
--- a/classes/check/certificateexpiry.php
+++ b/classes/check/certificateexpiry.php
@@ -38,6 +38,12 @@ use core\check\result;
  */
 class certificateexpiry extends check {
 
+    /** @var string Check ID */
+    protected string $id;
+
+    /** @var string Check name */
+    protected $name;
+
     /**
      * Constructor
      */


### PR DESCRIPTION
This branch fixes the dynamic property warnings listed in #836.