### PR TITLE
Fix redis_store->get function return type

### DIFF
--- a/classes/redis_store.php
+++ b/classes/redis_store.php
@@ -81,7 +81,7 @@ class redis_store implements \SimpleSAML\Store\StoreInterface {
      * @param string $key
      * @return mixed|null
      */
-    public function get($type, $key) {
+    public function get($type, $key): mixed {
         $value = $this->redis->get($this->make_key($type, $key));
         if ($value === false) {
             $value = null;


### PR DESCRIPTION
The redis_store->get function is incompatible with the StoreInterface->get function, which causes an exception while trying to log in.

