### PR TITLE
Moodle 4.5 deprecated print_error, use moodle_exception

### DIFF
--- a/autologin.php
+++ b/autologin.php
@@ -31,4 +31,4 @@ $success = required_param('success', PARAM_INT);
 \auth_saml2\auto_login::finish((bool)$success, new moodle_url($url));
 
 // Something strange went wrong, or somebody tried to directly link here.
-print_error('errorinvalidautologin', 'auth_saml2');
+throw new \moodle_exception('errorinvalidautologin', 'auth_saml2');


### PR DESCRIPTION
- Final deprecation of . Please use the  class instead.

  For more information see [MDL-74484](https://tracker.moodle.org/browse/MDL-74484)