### PR TITLE
[T19] Replace deprecated testcase classes with core_phpunit

### DIFF
--- a/tests/auth_test.php
+++ b/tests/auth_test.php
@@ -27,7 +27,7 @@ namespace auth_saml2;
  * @copyright   2021 Moodle Pty Ltd <support@moodle.com>
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class auth_saml2_test extends \advanced_testcase {
+class auth_saml2_test extends \core_phpunit\testcase {
     /**
      * Set up
      */

--- a/tests/autoloader_test.php
+++ b/tests/autoloader_test.php
@@ -26,7 +26,7 @@ require_once(__DIR__ . '/../_autoload.php');
  * @copyright   2018 Catalyst IT Australia {@link http://www.catalyst-au.net}
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class auth_saml2_autoloader_test extends advanced_testcase {
+class auth_saml2_autoloader_test extends \core_phpunit\testcase {
     public function test_it_loads_classes() {
         $classes = [
             \Psr\Log\LoggerInterface::class,

--- a/tests/form_regenerate_test.php
+++ b/tests/form_regenerate_test.php
@@ -30,7 +30,7 @@ use auth_saml2\form\regenerate;
  * @package    auth_saml2
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class auth_saml2_form_regenerate_testcase extends advanced_testcase {
+class auth_saml2_form_regenerate_testcase extends \core_phpunit\testcase {
     public function test_regenerate_certificate_form() {
         global $CFG, $DB, $USER;
         $this->resetAfterTest();

--- a/tests/generator_test.php
+++ b/tests/generator_test.php
@@ -26,7 +26,7 @@
  * @copyright   2021 Moodle Pty Ltd <support@moodle.com>
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class generator_testcase extends \advanced_testcase {
+class generator_testcase extends \core_phpunit\testcase {
     /**
      * Set up
      */

--- a/tests/group_rule_test.php
+++ b/tests/group_rule_test.php
@@ -30,7 +30,7 @@
  * @copyright  Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class auth_saml2_group_rule_test_testcase extends advanced_testcase {
+class auth_saml2_group_rule_test_testcase extends \core_phpunit\testcase {
 
     /**
      * Test we can get list of rules from config string.

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -34,7 +34,7 @@ require_once(__DIR__ . '/../locallib.php');
  * @copyright  Brendan Heywood <brendan@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class auth_saml2_locallib_testcase extends advanced_testcase {
+class auth_saml2_locallib_testcase extends \core_phpunit\testcase {
     /**
      * Regression test for Issue 132.
      */

--- a/tests/metadata_fetcher_test.php
+++ b/tests/metadata_fetcher_test.php
@@ -31,7 +31,7 @@ use auth_saml2\metadata_fetcher;
  * @copyright  Copyright (c) 2017 Blackboard Inc. (http://www.blackboard.com)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class auth_saml2_metadata_fetcher_testcase extends advanced_testcase {
+class auth_saml2_metadata_fetcher_testcase extends \core_phpunit\testcase {
 
     /** @var \Prophecy\Prophet */
     protected $prophet;

--- a/tests/metadata_parser_test.php
+++ b/tests/metadata_parser_test.php
@@ -31,7 +31,7 @@ use auth_saml2\metadata_parser;
  * @copyright  Copyright (c) 2017 Blackboard Inc. (http://www.blackboard.com)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class auth_saml2_metadata_parser_testcase extends basic_testcase {
+class auth_saml2_metadata_parser_testcase extends \core_phpunit\testcase {
 
     public function test_parse_metadata() {
         $xml = file_get_contents(__DIR__ . '/fixtures/metadata.xml');

--- a/tests/metadata_refresh_test.php
+++ b/tests/metadata_refresh_test.php
@@ -32,7 +32,7 @@ use auth_saml2\task\metadata_refresh;
  * @copyright  Copyright (c) 2017 Blackboard Inc. (http://www.blackboard.com)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class auth_saml2_metadata_refresh_testcase extends advanced_testcase {
+class auth_saml2_metadata_refresh_testcase extends \core_phpunit\testcase {
 
     /** @var \Prophecy\Prophet */
     protected $prophet;

--- a/tests/metadata_writer_test.php
+++ b/tests/metadata_writer_test.php
@@ -31,7 +31,7 @@ use auth_saml2\metadata_writer;
  * @copyright  Copyright (c) 2017 Blackboard Inc. (http://www.blackboard.com)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class auth_saml2_metadata_writer_testcase extends basic_testcase {
+class auth_saml2_metadata_writer_testcase extends \core_phpunit\testcase {
 
     public function test_write_default_path() {
         global $CFG;

--- a/tests/redis_store_test.php
+++ b/tests/redis_store_test.php
@@ -31,7 +31,7 @@ use auth_saml2\redis_store;
  * @copyright  Copyright (c) 2017 Blackboard Inc. (http://www.blackboard.com)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class auth_saml2_redis_store_testcase extends advanced_testcase {
+class auth_saml2_redis_store_testcase extends \core_phpunit\testcase {
 
     /**
      * @var null|\Redis

--- a/tests/saml2_sitedata_test.php
+++ b/tests/saml2_sitedata_test.php
@@ -26,7 +26,7 @@ require_once(__DIR__ . '/../_autoload.php');
  * @copyright   2018 Catalyst IT Australia {@link http://www.catalyst-au.net}
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class auth_saml2_sitedata_test extends advanced_testcase {
+class auth_saml2_sitedata_test extends \core_phpunit\testcase {
     public function test_it_creates_the_directory_if_it_does_not_exist() {
         global $CFG;
 

--- a/tests/setting_idpmetadata_test.php
+++ b/tests/setting_idpmetadata_test.php
@@ -29,7 +29,7 @@ require_once(__DIR__ . '/../_autoload.php');
  * @copyright   2018 Catalyst IT Australia {@link http://www.catalyst-au.net}
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class setting_idpmetadata_test extends advanced_testcase {
+class setting_idpmetadata_test extends \core_phpunit\testcase {
     /** @var setting_idpmetadata */
     private static $config;
 

--- a/tests/simplesamlphp_upgrade_test.php
+++ b/tests/simplesamlphp_upgrade_test.php
@@ -28,7 +28,7 @@
  * @package    auth_saml2
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class auth_saml2_simplesamlphp_upgrade_testcase extends advanced_testcase {
+class auth_saml2_simplesamlphp_upgrade_testcase extends \core_phpunit\testcase {
 
     /**
      * Test to ensure that composer files are removed from compiled extlib/simplesamlphp.

--- a/tests/ssl_algorithm_test.php
+++ b/tests/ssl_algorithm_test.php
@@ -24,7 +24,7 @@ use auth_saml2\ssl_algorithms;
  * @copyright  Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class auth_saml2_ssl_algorithms_test extends basic_testcase {
+class auth_saml2_ssl_algorithms_test extends \core_phpunit\testcase {
     public function test_default_saml_signature_algorithm_is_valid_saml_signature_algorithm() {
         $this->assertTrue(array_key_exists(ssl_algorithms::get_default_saml_signature_algorithm(),
             ssl_algorithms::get_valid_saml_signature_algorithms()));

--- a/tests/user_extractor_test.php
+++ b/tests/user_extractor_test.php
@@ -33,7 +33,7 @@ use auth_saml2\user_extractor;
  * @copyright  2021 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class auth_saml2_user_extractor_test extends advanced_testcase {
+class auth_saml2_user_extractor_test extends \core_phpunit\testcase {
 
     /**
      * A helper function to create a custom profile field.

--- a/tests/user_fields_test.php
+++ b/tests/user_fields_test.php
@@ -33,7 +33,7 @@ use auth_saml2\user_fields;
  * @copyright  2021 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class auth_saml2_user_fields_test extends advanced_testcase {
+class auth_saml2_user_fields_test extends \core_phpunit\testcase {
 
     /**
      * A helper function to create a custom profile field.


### PR DESCRIPTION
Adds a fix so unit tests can run with Tōtara 19.

I created this MR against the branch currently used for Tōtara 13+ sites but it'll likely need a new TOTARA_19_STABLE branch.
