### PR TITLE
bugfix: purge sessions on simplesaml upgrade

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -410,5 +410,11 @@ function xmldb_auth_saml2_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2023100300, 'auth', 'saml2');
     }
 
+    if ($oldversion < 2024092001) {
+        // Due to simplesaml library update, we need to purge all existing sessions.
+        $DB->delete_records('auth_saml2_kvstore', ['type' => 'session']);
+        upgrade_plugin_savepoint(true, 2024092001, 'auth', 'saml2');
+    }
+
     return true;
 }


### PR DESCRIPTION
**Background**
- Further testing of simplesaml update in https://github.com/catalyst/moodle-auth_saml2/pull/907 has uncovered an edge case where if a user is logged in and the plugin is upgraded, their existing session gets stuck and the user cannot log in OR out. They need to purge their browser cache entirely.
    - This seems to be because the token format/deserialisation has changed between simplesaml versions, so it cannot deserialise the existing token and gets stuck 

**Changes**
- Adds upgrade step for the version bumped in https://github.com/catalyst/moodle-auth_saml2/pull/907 to purge existing sessions from the kvstore

**Testing**
- This requires saml setup locally, which I have.
- Using previous commit f7f1e992482962d916b2dfc6df4d7b707eee7236
- Log in as a user using saml
- Switch to f4a282ba0204729f60b376b9c2d9bbff531301c7
- Try and log out as the user, it will throw an exception.
- Switch to this PR's branch, and run the site upgrade (with newly added upgrade step that deletes existing sessions)
- Confirm the user can now log in/out without error

I've done the above ^^ on my local environment and it worked