### PR TITLE
Use explicit functions to retrieve optional config

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -146,40 +146,40 @@ function auth_saml2_get_sp_metadata($baseurl = '') {
         $metaArray20['NameIDFormat'] = $format;
     }
 
-    $name = $spconfig->getLocalizedString('name', NULL);
-    $attributes = $spconfig->getArray('attributes', array());
+    $name = $spconfig->getOptionalLocalizedString('name', NULL);
+    $attributes = $spconfig->getOptionalArray('attributes', []);
 
     if ($name !== NULL && !empty($attributes)) {
         $metaArray20['name'] = $name;
         $metaArray20['attributes'] = $attributes;
-        $metaArray20['attributes.required'] = $spconfig->getArray('attributes.required', array());
+        $metaArray20['attributes.required'] = $spconfig->getOptionalArray('attributes.required', []);
 
         if (empty($metaArray20['attributes.required'])) {
             unset($metaArray20['attributes.required']);
         }
 
-        $description = $spconfig->getArray('description', NULL);
+        $description = $spconfig->getOptionalArray('description', NULL);
         if ($description !== NULL) {
             $metaArray20['description'] = $description;
         }
 
-        $nameFormat = $spconfig->getString('attributes.NameFormat', NULL);
+        $nameFormat = $spconfig->getOptionalString('attributes.NameFormat', NULL);
         if ($nameFormat !== NULL) {
             $metaArray20['attributes.NameFormat'] = $nameFormat;
         }
     }
 
     // add organization info
-    $orgName = $spconfig->getLocalizedString('OrganizationName', NULL);
+    $orgName = $spconfig->getOptionalLocalizedString('OrganizationName', NULL);
     if ($orgName !== NULL) {
         $metaArray20['OrganizationName'] = $orgName;
 
-        $metaArray20['OrganizationDisplayName'] = $spconfig->getLocalizedString('OrganizationDisplayName', NULL);
+        $metaArray20['OrganizationDisplayName'] = $spconfig->getOptionalLocalizedString('OrganizationDisplayName', NULL);
         if ($metaArray20['OrganizationDisplayName'] === NULL) {
             $metaArray20['OrganizationDisplayName'] = $orgName;
         }
 
-        $metaArray20['OrganizationURL'] = $spconfig->getLocalizedString('OrganizationURL', NULL);
+        $metaArray20['OrganizationURL'] = $spconfig->getOptionalLocalizedString('OrganizationURL', NULL);
         if ($metaArray20['OrganizationURL'] === NULL) {
             throw new SimpleSAML_Error_Exception('If OrganizationName is set, OrganizationURL must also be set.');
         }
@@ -193,10 +193,10 @@ function auth_saml2_get_sp_metadata($baseurl = '') {
     }
 
     // add technical contact
-    $email = $config->getString('technicalcontact_email', 'na@example.org', FALSE);
+    $email = $config->getOptionalString('technicalcontact_email', 'na@example.org');
     if ($email && $email !== 'na@example.org') {
         $techcontact['emailAddress'] = $email;
-        $techcontact['name'] = $config->getString('technicalcontact_name', NULL);
+        $techcontact['name'] = $config->getOptionalString('technicalcontact_name', NULL);
         $techcontact['contactType'] = 'technical';
         $metaArray20['contacts'][] = \SimpleSAML\Utils\Config\Metadata::getContact($techcontact);
     }

--- a/vendor/simplesamlphp/saml2/src/SAML2/Configuration/SimpleSAMLConverter.php
+++ b/vendor/simplesamlphp/saml2/src/SAML2/Configuration/SimpleSAMLConverter.php
@@ -81,7 +81,7 @@ class SimpleSAMLConverter
             $extracted['certificateData'] = $configuration->getString($prefix.'certificate');
         }
 
-        $extracted['assertionEncryptionEnabled'] = $configuration->getBoolean('assertion.encryption', false);
+        $extracted['assertionEncryptionEnabled'] = $configuration->getOptinalBoolean('assertion.encryption', false);
 
         if ($configuration->hasValue('sharedKey')) {
             $extracted['sharedKey'] = $configuration->getString('sharedKey');
@@ -101,7 +101,7 @@ class SimpleSAMLConverter
      */
     protected static function enrichForIdentityProvider(Configuration $configuration, array &$baseConfiguration) : void
     {
-        $baseConfiguration['base64EncodedAttributes'] = $configuration->getBoolean('base64attributes', false);
+        $baseConfiguration['base64EncodedAttributes'] = $configuration->getOptionalBoolean('base64attributes', false);
         $baseConfiguration['entityId'] = $configuration->getString('entityid');
     }
 
@@ -133,22 +133,22 @@ class SimpleSAMLConverter
         array &$baseConfiguration
     ) : void {
         if ($configuration->hasValue('sharedKey')) {
-            $baseConfiguration['sharedKey'] = $configuration->getString('sharedKey', null);
+            $baseConfiguration['sharedKey'] = $configuration->getOptionalString('sharedKey', null);
         }
 
         if ($configuration->hasValue('new_privatekey')) {
             $baseConfiguration['privateKeys'][] = new PrivateKey(
                 $configuration->getString('new_privatekey'),
                 PrivateKey::NAME_NEW,
-                $configuration->getString('new_privatekey_pass', null)
+                $configuration->getOptionalString('new_privatekey_pass', null)
             );
         }
 
-        if ($configuration->getBoolean('assertion.encryption', false)) {
+        if ($configuration->getOptionalBoolean('assertion.encryption', false)) {
             $baseConfiguration['privateKeys'][] = new PrivateKey(
                 $configuration->getString('privatekey'),
                 PrivateKey::NAME_DEFAULT,
-                $configuration->getString('privatekey_pass', null)
+                $configuration->getOptionalString('privatekey_pass', null)
             );
 
             if ($configuration->hasValue('encryption.blacklisted-algorithms')) {


### PR DESCRIPTION
The SimpleSAMLphp library introduced a dedicated function for retrieving optional configuration values. Updated the code to utilize this explicit function.

Fixes https://github.com/catalyst/moodle-auth_saml2/issues/842