### PR TITLE
Fix Behat execute helper method arguments.

### DIFF
--- a/tests/behat/behat_auth_saml2.php
+++ b/tests/behat/behat_auth_saml2.php
@@ -384,7 +384,7 @@ EOF;
      * Note: The contextapi does not support a callback.
      *
      * @param string|array $contextapi context in which api is defined.
-     * @param array|mixed $params list of params to pass or a single parameter
+     * @param mixed $params list of params to pass or a single parameter
      */
     protected function execute(
         string|array $contextapi,

--- a/tests/behat/behat_auth_saml2.php
+++ b/tests/behat/behat_auth_saml2.php
@@ -379,26 +379,22 @@ EOF;
     }
 
     /**
-     * Execute.
+     * Helper function to execute api in a given context.
      *
-     * @param string $contextapi context in which api is defined.
-     * @param array $params list of params to pass.
+     * Note: The contextapi does not support a callback.
+     *
+     * @param string|array $contextapi context in which api is defined.
+     * @param array|mixed $params list of params to pass or a single parameter
      */
-    protected function execute($contextapi, $params = []) {
+    protected function execute(
+        string|array $contextapi,
+        mixed $params = [],
+    ): void {
         global $CFG;
 
         // We allow usage of depricated behat steps for now.
         $CFG->behat_usedeprecated = true;
 
-        // If newer Moodle, use the correct version.
-        if ($CFG->branch >= 29) {
-            return parent::execute($contextapi, $params);
-        }
-
-        // Backported for Moodle 27 and 28.
-        list($class, $method) = explode("::", $contextapi);
-        $object = behat_context_helper::get($class);
-        $object->setMinkParameter('base_url', $CFG->wwwroot);
-        return call_user_func_array([$object, $method], $params);
+        parent::execute($contextapi, $params);
     }
 }


### PR DESCRIPTION
Upstream changes in MDL-86231 amended the method contract. Also remove some old backwards compat code, given this version of the plugin has explicit support only from 5.0.

Fixes #917.