### PR TITLE
[#922] Dont escape url during connectivity test

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * Authenticate using an embeded SimpleSamlPhp instance
  *
@@ -23,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->libdir.'/authlib.php');
+require_once($CFG->libdir . '/authlib.php');
 
 /**
  * Plugin for Saml2 authentication.
@@ -33,5 +34,4 @@ require_once($CFG->libdir.'/authlib.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class auth_plugin_saml2 extends \auth_saml2\auth {
-
 }

--- a/availableidps.php
+++ b/availableidps.php
@@ -34,8 +34,10 @@ $heading = get_string('manageidpsheading', 'auth_saml2');
 
 $PAGE->set_pagelayout('standard');
 
-auth_saml2_admin_nav($heading,
-    "/auth/saml2/availableidps.php");
+auth_saml2_admin_nav(
+    $heading,
+    "/auth/saml2/availableidps.php"
+);
 
 $PAGE->requires->css('/auth/saml2/styles.css');
 

--- a/cert.php
+++ b/cert.php
@@ -27,8 +27,10 @@ require_once(__DIR__ . '/../../config.php');
 // @codingStandardsIgnoreEnd
 require('setup.php');
 
-auth_saml2_admin_nav(get_string('certificatedetails', 'auth_saml2'),
-    '/auth/saml2/cert.php');
+auth_saml2_admin_nav(
+    get_string('certificatedetails', 'auth_saml2'),
+    '/auth/saml2/cert.php'
+);
 
 $path = $saml2auth->certcrt;
 $data = openssl_x509_parse(file_get_contents($path));
@@ -38,4 +40,3 @@ echo get_string('certificatedetailshelp', 'auth_saml2');
 echo "<p>$path</p>";
 echo pretty_print($data);
 echo $OUTPUT->footer();
-

--- a/certificatelock.php
+++ b/certificatelock.php
@@ -39,9 +39,7 @@ $form = new \auth_saml2\form\lockcertificate();
 $settingspage = new moodle_url('/admin/settings.php?section=authsettingsaml2');
 
 if ($data = $form->get_data()) {
-
     if ($form->is_submitted()) {
-
         $certfiles = [$saml2auth->certpem, $saml2auth->certcrt];
         if (isset($data->unlockcertsbutton)) {
             // Change the permissions in order to regenerate if unlocked.

--- a/classes/admin/saml2_settings.php
+++ b/classes/admin/saml2_settings.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 namespace auth_saml2\admin;
 
 /**

--- a/classes/admin/setting_idpmetadata.php
+++ b/classes/admin/setting_idpmetadata.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 namespace auth_saml2\admin;
 
 use admin_setting_configtextarea;
@@ -49,7 +50,8 @@ class setting_idpmetadata extends admin_setting_configtextarea {
             '',
             PARAM_RAW,
             80,
-            5);
+            5
+        );
     }
 
     /**
@@ -132,8 +134,13 @@ class setting_idpmetadata extends admin_setting_configtextarea {
      * @param mixed $oldidps
      * @param int $activedefault
      */
-    private function process_idp_xml(idp_data $idp, DOMElement $idpelements, DOMXPath $xpath,
-                                        &$oldidps, $activedefault = 0) {
+    private function process_idp_xml(
+        idp_data $idp,
+        DOMElement $idpelements,
+        DOMXPath $xpath,
+        &$oldidps,
+        $activedefault = 0
+    ) {
         global $DB;
         $entityid = $idpelements->getAttribute('entityID');
 
@@ -206,7 +213,7 @@ class setting_idpmetadata extends admin_setting_configtextarea {
     public function get_idps_data($value) {
         global $CFG;
 
-        require_once($CFG->libdir.'/filelib.php');
+        require_once($CFG->libdir . '/filelib.php');
 
         $parser = new idp_parser();
         $idps = $parser->parse($value);

--- a/classes/admin/setting_idpmetadata_exception.php
+++ b/classes/admin/setting_idpmetadata_exception.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 namespace auth_saml2\admin;
 
 use Exception;

--- a/classes/api.php
+++ b/classes/api.php
@@ -27,7 +27,6 @@ use moodle_url;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class api {
-
     /**
      * IdP logout callback. Called only when logout is initiated from IdP.
      * {@see \auth_saml2\sp\saml2-logout}
@@ -51,7 +50,7 @@ class api {
 
         // In SSP should do this for us but remove stored SP session data.
         $storeclass = $saml2config['store.type'];
-        $store = new $storeclass;
+        $store = new $storeclass();
         $store->delete('session', $sessid);
 
         redirect(new moodle_url($state['ReturnTo']));

--- a/classes/auth.php
+++ b/classes/auth.php
@@ -515,7 +515,7 @@ class auth extends \auth_plugin_base {
             global $PAGE, $ME;
             $PAGE->requires->js_call_amd('auth_saml2/connectivity_test', 'init', [
                 $this->config->testendpoint,
-                (new moodle_url($ME, ['saml' => 'on']))->out(),
+                (new moodle_url($ME, ['saml' => 'on']))->out(escaped: false),
             ]);
             return false;
         }

--- a/classes/auth.php
+++ b/classes/auth.php
@@ -37,9 +37,9 @@ use moodle_exception;
 use stdClass;
 
 global $CFG;
-require_once($CFG->libdir.'/authlib.php');
-require_once($CFG->dirroot.'/login/lib.php');
-require_once(__DIR__.'/../locallib.php');
+require_once($CFG->libdir . '/authlib.php');
+require_once($CFG->dirroot . '/login/lib.php');
+require_once(__DIR__ . '/../locallib.php');
 
 /**
  * Plugin for Saml2 authentication.
@@ -134,7 +134,7 @@ class auth extends \auth_plugin_base {
         $this->certpem = $this->get_file("{$this->spname}.pem");
         $this->certcrt = $this->get_file("{$this->spname}.crt");
 
-        $this->config = (object) array_merge($this->defaults, (array) get_config('auth_saml2') );
+        $this->config = (object) array_merge($this->defaults, (array) get_config('auth_saml2'));
 
         // Parsed IdP metadata, either a list of IdP metadata urls or a single XML blob.
         $parser = new idp_parser();
@@ -232,7 +232,7 @@ class auth extends \auth_plugin_base {
 
             // If SSP logs to tmp file we want these to also go there.
             if ($this->config->logtofile) {
-                require_once(__DIR__.'/../setup.php');
+                require_once(__DIR__ . '/../setup.php');
                 \SimpleSAML\Logger::debug('auth_saml2: ' . $msg);
             }
         }
@@ -273,8 +273,14 @@ class auth extends \auth_plugin_base {
 
             // Moodle Workplace - Check IdP's tenant availability.
             // Check if function exists required for Totara 12 compatibility.
-            if (class_exists(\tool_tenant\local\auth\saml2\manager::class) && !component_class_callback('\tool_tenant\local\auth\saml2\manager',
-                    'issuer_available', [$idp->md5entityid], true)) {
+            if (
+                class_exists(\tool_tenant\local\auth\saml2\manager::class) && !component_class_callback(
+                    '\tool_tenant\local\auth\saml2\manager',
+                    'issuer_available',
+                    [$idp->md5entityid],
+                    true
+                )
+            ) {
                 continue;
             }
 
@@ -432,8 +438,10 @@ class auth extends \auth_plugin_base {
 
         // For Behat tests, clear the wantsurl if it has ended up pointing to the fixture. This
         // happens in older browsers which don't support the Referrer-Policy header used by fixture.
-        if (defined('BEHAT_SITE_RUNNING') && !empty($SESSION->wantsurl) &&
-                strpos($SESSION->wantsurl, '/auth/saml2/tests/fixtures/') !== false) {
+        if (
+            defined('BEHAT_SITE_RUNNING') && !empty($SESSION->wantsurl) &&
+                strpos($SESSION->wantsurl, '/auth/saml2/tests/fixtures/') !== false
+        ) {
             unset($SESSION->wantsurl);
         }
 
@@ -451,7 +459,6 @@ class auth extends \auth_plugin_base {
             $this->log(__FUNCTION__ . ' exit');
             return;
         }
-
     }
 
     /**
@@ -533,8 +540,10 @@ class auth extends \auth_plugin_base {
         //
         // This isn't needed when duallogin is on because $saml will default to 0
         // and duallogin is not part of the request.
-        if ((isset($SESSION->saml) && $SESSION->saml == 0) && $this->config->duallogin == saml2_settings::OPTION_DUAL_LOGIN_NO
-                && $this->can_skip_redirect()) {
+        if (
+            (isset($SESSION->saml) && $SESSION->saml == 0) && $this->config->duallogin == saml2_settings::OPTION_DUAL_LOGIN_NO
+                && $this->can_skip_redirect()
+        ) {
             $this->log(__FUNCTION__ . ' skipping due to no sso session');
             return false;
         }
@@ -596,7 +605,7 @@ class auth extends \auth_plugin_base {
     public function saml_login() {
         global $CFG, $SESSION;
 
-        require_once(__DIR__.'/../setup.php');
+        require_once(__DIR__ . '/../setup.php');
         require_once("$CFG->dirroot/login/lib.php");
 
         // Set the default IdP to be the first in the list. Used when dual login is disabled.
@@ -715,8 +724,11 @@ class auth extends \auth_plugin_base {
         // Moodle Workplace - Check IdP's tenant availability, for new user pre-allocate to tenant.
         // Check if function exists required for Totara 12 compatibility.
         if (class_exists(\tool_tenant\local\auth\saml2\manager::class)) {
-            component_class_callback('\tool_tenant\local\auth\saml2\manager', 'complete_login_hook',
-                [$SESSION->saml2idp ?? '', $uid, $user]);
+            component_class_callback(
+                '\tool_tenant\local\auth\saml2\manager',
+                'complete_login_hook',
+                [$SESSION->saml2idp ?? '', $uid, $user]
+            );
         }
 
         $newuser = false;
@@ -757,7 +769,7 @@ class auth extends \auth_plugin_base {
                 }
 
                 $this->log(__FUNCTION__ . " user '$user->username' is not in moodle so autocreating");
-                require_once($CFG->dirroot.'/user/lib.php');
+                require_once($CFG->dirroot . '/user/lib.php');
 
                 // Various values that user_create_user doesn't validate or set.
                 $user->confirmed = 1;
@@ -795,7 +807,7 @@ class auth extends \auth_plugin_base {
                 $this->error_page(get_string('suspendeduser', 'auth_saml2', $uid));
             }
 
-            $this->log(__FUNCTION__ . ' found user '.$user->username);
+            $this->log(__FUNCTION__ . ' found user ' . $user->username);
         }
 
         if (!$this->config->anyauth && $user->auth != 'saml2') {
@@ -850,13 +862,13 @@ class auth extends \auth_plugin_base {
 
         $wantsurl = core_login_get_return_url();
         // If we are not on the page we want, then redirect to it (unless this is CLI).
-        if ( qualified_me() !== false && qualified_me() !== $wantsurl ) {
+        if (qualified_me() !== false && qualified_me() !== $wantsurl) {
             $this->log(__FUNCTION__ . " redirecting to $wantsurl");
             unset($SESSION->wantsurl);
             redirect($wantsurl);
             exit;
         } else {
-            $this->log(__FUNCTION__ . " continuing onto " . qualified_me() );
+            $this->log(__FUNCTION__ . " continuing onto " . qualified_me());
         }
 
         return;
@@ -883,11 +895,11 @@ class auth extends \auth_plugin_base {
      */
     protected function handle_blocked_access() {
         switch ($this->config->flagresponsetype) {
-            case saml2_settings::OPTION_FLAGGED_LOGIN_REDIRECT :
+            case saml2_settings::OPTION_FLAGGED_LOGIN_REDIRECT:
                 $this->redirect_blocked_access();
                 break;
-            case saml2_settings::OPTION_FLAGGED_LOGIN_MESSAGE :
-            default :
+            case saml2_settings::OPTION_FLAGGED_LOGIN_MESSAGE:
+            default:
                 $this->error_page($this->config->flagmessage);
                 break;
         }
@@ -920,7 +932,7 @@ class auth extends \auth_plugin_base {
     public function is_access_allowed_for_member($attributes) {
 
         // If there is no encumberance attribute configured in Moodle, let them pass.
-        if (empty($this->config->grouprules) ) {
+        if (empty($this->config->grouprules)) {
             return true;
         }
 
@@ -992,7 +1004,7 @@ class auth extends \auth_plugin_base {
      * @throws Exception
      * @throws coding_exception
      */
-    public function update_user_record_from_attribute_map(&$user, $attributes, $newuser= false) {
+    public function update_user_record_from_attribute_map(&$user, $attributes, $newuser = false) {
         global $CFG;
 
         $mapconfig = get_config('auth_saml2');
@@ -1002,16 +1014,15 @@ class auth extends \auth_plugin_base {
         foreach ($allkeys as $key) {
             if (preg_match('/^field_updatelocal_(.+)$/', $key, $match)) {
                 $field = $match[1];
-                if (!empty($mapconfig->{'field_map_'.$field})) {
-                    $attr = $mapconfig->{'field_map_'.$field};
-                    $updateonlogin = $mapconfig->{'field_updatelocal_'.$field} === 'onlogin';
+                if (!empty($mapconfig->{'field_map_' . $field})) {
+                    $attr = $mapconfig->{'field_map_' . $field};
+                    $updateonlogin = $mapconfig->{'field_updatelocal_' . $field} === 'onlogin';
 
                     if ($newuser || $updateonlogin) {
                         // Basic error handling, check to see if the attributes exist before mapping the data.
                         if (array_key_exists($attr, $attributes)) {
                             // Handing an empty array of attributes.
                             if (!empty($attributes[$attr])) {
-
                                 // If can't have accounts with the same emails, check if email is taken before update a new user.
                                 if ($field == 'email' && empty($CFG->allowaccountssameemail)) {
                                     $email = $attributes[$attr][0];
@@ -1063,7 +1074,7 @@ class auth extends \auth_plugin_base {
     public function update_user_profile_fields(&$user, $attributes, $newuser = false) {
         global $CFG;
         if ($this->update_user_record_from_attribute_map($user, $attributes, $newuser)) {
-            require_once($CFG->dirroot.'/user/lib.php');
+            require_once($CFG->dirroot . '/user/lib.php');
             if ($user->description === true) {
                 // Function get_complete_user_data() sets description = true to avoid keeping in memory.
                 // If set to true - don't update based on data from this call.
@@ -1168,7 +1179,7 @@ class auth extends \auth_plugin_base {
         // gets called by the normal core process.
         require_logout();
 
-        require_once(__DIR__.'/../setup.php');
+        require_once(__DIR__ . '/../setup.php');
 
         // We just loaded the SP session which replaces the Moodle so we lost
         // the session data, lets temporarily restore the IdP.
@@ -1179,8 +1190,15 @@ class auth extends \auth_plugin_base {
         // still delete the local SP cookie so we force auth again next time.
         $cookiename = $saml2config['session.cookie.name'];
         $cookiesecure = is_moodle_cookie_secure();
-        setcookie($cookiename, '', time() - HOURSECS, $CFG->sessioncookiepath, $CFG->sessioncookiedomain,
-              $cookiesecure, $CFG->cookiehttponly);
+        setcookie(
+            $cookiename,
+            '',
+            time() - HOURSECS,
+            $CFG->sessioncookiepath,
+            $CFG->sessioncookiedomain,
+            $cookiesecure,
+            $CFG->cookiehttponly
+        );
 
         // Do not attempt to log out of the IdP.
         if (!$this->config->attemptsignout) {
@@ -1253,9 +1271,11 @@ class auth extends \auth_plugin_base {
             $mform = new \auth_saml2\form\testidpselect($action, ['metadataentities' => $this->metadataentities]);
             $mform->display();
         } else {
-            echo $OUTPUT->render(new notification(get_string('test_noticetestrequirements', 'auth_saml2'),
-                notification::NOTIFY_WARNING, false));
-
+            echo $OUTPUT->render(new notification(
+                get_string('test_noticetestrequirements', 'auth_saml2'),
+                notification::NOTIFY_WARNING,
+                false
+            ));
         }
     }
 
@@ -1293,18 +1313,32 @@ class auth extends \auth_plugin_base {
             return;
         }
 
-        $cookiename = 'MOODLEIDP1_'.$CFG->sessioncookie;
+        $cookiename = 'MOODLEIDP1_' . $CFG->sessioncookie;
 
         $cookiesecure = is_moodle_cookie_secure();
 
         // Delete old cookie.
-        setcookie($cookiename, '', time() - HOURSECS, $CFG->sessioncookiepath, $CFG->sessioncookiedomain,
-                  $cookiesecure, $CFG->cookiehttponly);
+        setcookie(
+            $cookiename,
+            '',
+            time() - HOURSECS,
+            $CFG->sessioncookiepath,
+            $CFG->sessioncookiedomain,
+            $cookiesecure,
+            $CFG->cookiehttponly
+        );
 
         if ($idp !== '') {
             // Set username cookie for 60 days.
-            setcookie($cookiename, $idp, time() + (DAYSECS * 60), $CFG->sessioncookiepath, $CFG->sessioncookiedomain,
-                      $cookiesecure, $CFG->cookiehttponly);
+            setcookie(
+                $cookiename,
+                $idp,
+                time() + (DAYSECS * 60),
+                $CFG->sessioncookiepath,
+                $CFG->sessioncookiedomain,
+                $cookiesecure,
+                $CFG->cookiehttponly
+            );
         }
     }
 
@@ -1320,7 +1354,7 @@ class auth extends \auth_plugin_base {
             return '';
         }
 
-        $cookiename = 'MOODLEIDP1_'.$CFG->sessioncookie;
+        $cookiename = 'MOODLEIDP1_' . $CFG->sessioncookie;
 
         if (empty($_COOKIE[$cookiename])) {
             return '';

--- a/classes/auto_login.php
+++ b/classes/auto_login.php
@@ -98,8 +98,10 @@ class auto_login {
                 }
                 // If the cookie is set to the same value it was last time we looked, do nothing.
                 $currentcookie = $_COOKIE[$auth->config->autologincookie];
-                if (!empty($SESSION->auth_saml2_lastautologincookie) &&
-                        $SESSION->auth_saml2_lastautologincookie === $currentcookie) {
+                if (
+                    !empty($SESSION->auth_saml2_lastautologincookie) &&
+                        $SESSION->auth_saml2_lastautologincookie === $currentcookie
+                ) {
                     return;
                 }
                 break;

--- a/classes/check/certificateexpiry.php
+++ b/classes/check/certificateexpiry.php
@@ -37,7 +37,6 @@ use core\check\result;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class certificateexpiry extends check {
-
     /** @var string Check ID */
     protected string $id;
 
@@ -61,7 +60,8 @@ class certificateexpiry extends check {
     public function get_action_link(): ?\action_link {
         return new \action_link(
             new \moodle_url('/auth/saml2/cert.php'),
-            get_string('certificatedetails', 'auth_saml2'));
+            get_string('certificatedetails', 'auth_saml2')
+        );
     }
 
     /**
@@ -101,4 +101,3 @@ class certificateexpiry extends check {
         return new result(result::OK, $summary, '');
     }
 }
-

--- a/classes/form/availableidps.php
+++ b/classes/form/availableidps.php
@@ -41,7 +41,6 @@ require_once("$CFG->libdir/formslib.php");
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class availableidps extends moodleform {
-
     /**
      * Definition
      */
@@ -52,50 +51,77 @@ class availableidps extends moodleform {
         $metadataentities = $this->_customdata['metadataentities'];
 
         foreach ($metadataentities as $metadataurl => $idpentities) {
-
             foreach ($idpentities as $idpentityid => $idpentity) {
-                $fieldkey = 'metadataentities['.$metadataurl.']['.$idpentityid.']';
+                $fieldkey = 'metadataentities[' . $metadataurl . '][' . $idpentityid . ']';
 
                 // Add the start of the row, entiyid, name, etc.
-                $mform->addElement('header',  $idpentityid.'header', $idpentity['name']);
-                $mform->addElement('hidden', $fieldkey.'[id]');
-                $mform->setType($fieldkey.'[id]', PARAM_INT);
+                $mform->addElement('header', $idpentityid . 'header', $idpentity['name']);
+                $mform->addElement('hidden', $fieldkey . '[id]');
+                $mform->setType($fieldkey . '[id]', PARAM_INT);
 
                 // List the source.
-                $mform->addElement('html', \html_writer::div(get_string('source', 'auth_saml2', $idpentity['entityid']),
-                    'alert p-2 bg-gray bg-gray020'));
+                $mform->addElement('html', \html_writer::div(
+                    get_string('source', 'auth_saml2', $idpentity['entityid']),
+                    'alert p-2 bg-gray bg-gray020'
+                ));
 
                 // Add the displayname textbox.
-                $mform->addElement('text', $fieldkey.'[displayname]',
-                    get_string('multiidp:label:displayname', 'auth_saml2'), ['placeholder' => $idpentity['defaultname']]);
-                $mform->setType($fieldkey.'[displayname]', PARAM_TEXT);
+                $mform->addElement(
+                    'text',
+                    $fieldkey . '[displayname]',
+                    get_string('multiidp:label:displayname', 'auth_saml2'),
+                    ['placeholder' => $idpentity['defaultname']]
+                );
+                $mform->setType($fieldkey . '[displayname]', PARAM_TEXT);
 
                 // Add the alias textbox.
-                $mform->addElement('text', $fieldkey.'[alias]', get_string('multiidp:label:alias', 'auth_saml2'));
-                $mform->setType($fieldkey.'[alias]', PARAM_TEXT);
+                $mform->addElement('text', $fieldkey . '[alias]', get_string('multiidp:label:alias', 'auth_saml2'));
+                $mform->setType($fieldkey . '[alias]', PARAM_TEXT);
 
                 // Add the activeidp checkbox.
-                $mform->addElement('advcheckbox', $fieldkey.'[activeidp]',
-                    get_string('status', 'auth_saml2'), get_string('multiidp:label:active', 'auth_saml2'), [], [false, true]);
+                $mform->addElement(
+                    'advcheckbox',
+                    $fieldkey . '[activeidp]',
+                    get_string('status', 'auth_saml2'),
+                    get_string('multiidp:label:active', 'auth_saml2'),
+                    [],
+                    [false, true]
+                );
 
                 // Add the defaultidp checkbox.
-                $mform->addElement('advcheckbox', $fieldkey.'[defaultidp]',
-                    get_string('multiidp:label:defaultidp', 'auth_saml2'), '', [], [false, true]);
+                $mform->addElement(
+                    'advcheckbox',
+                    $fieldkey . '[defaultidp]',
+                    get_string('multiidp:label:defaultidp', 'auth_saml2'),
+                    '',
+                    [],
+                    [false, true]
+                );
 
                 // Add the adminidp checkbox.
-                $mform->addElement('advcheckbox', $fieldkey.'[adminidp]',
-                    get_string('multiidp:label:admin', 'auth_saml2'), '', [], [false, true]);
-                $mform->addHelpButton($fieldkey.'[adminidp]', 'multiidp:label:admin', 'auth_saml2');
+                $mform->addElement(
+                    'advcheckbox',
+                    $fieldkey . '[adminidp]',
+                    get_string('multiidp:label:admin', 'auth_saml2'),
+                    '',
+                    [],
+                    [false, true]
+                );
+                $mform->addHelpButton($fieldkey . '[adminidp]', 'multiidp:label:admin', 'auth_saml2');
 
                 // Add whitelisted IP for redirection to this IdP.
-                $mform->addElement('textarea', $fieldkey.'[whitelist]', get_string('multiidp:label:whitelist', 'auth_saml2'));
-                $mform->addHelpButton($fieldkey.'[whitelist]', 'multiidp:label:whitelist', 'auth_saml2');
-                $mform->setType($fieldkey.'[whitelist]', PARAM_TEXT);
+                $mform->addElement('textarea', $fieldkey . '[whitelist]', get_string('multiidp:label:whitelist', 'auth_saml2'));
+                $mform->addHelpButton($fieldkey . '[whitelist]', 'multiidp:label:whitelist', 'auth_saml2');
+                $mform->setType($fieldkey . '[whitelist]', PARAM_TEXT);
 
                 // Moodle Workplace - Tenant availability edit button.
                 if (class_exists('\tool_tenant\local\auth\saml2\manager')) {
-                    $links = component_class_callback('\tool_tenant\local\auth\saml2\manager',
-                        'issuer_tenant_availability_button', [['id' => $idpentityid, 'name' => $idpentity['name']]], '');
+                    $links = component_class_callback(
+                        '\tool_tenant\local\auth\saml2\manager',
+                        'issuer_tenant_availability_button',
+                        [['id' => $idpentityid, 'name' => $idpentity['name']]],
+                        ''
+                    );
                     $mform->addElement('static', 'tenantbutton', '&nbsp;', $links);
                 }
             }
@@ -103,6 +129,4 @@ class availableidps extends moodleform {
 
         $this->add_action_buttons();
     }
-
 }
-

--- a/classes/form/lockcertificate.php
+++ b/classes/form/lockcertificate.php
@@ -59,8 +59,11 @@ class lockcertificate extends moodleform {
             $certslockwarning .= $OUTPUT->notification(get_string('certificatelock_lockedmessage', 'auth_saml2'), 'warning');
             $certslockwarning .= html_writer::end_div();
             $mform->addElement('html', $certslockwarning);
-            $buttonarray[] = &$mform->createElement('submit', 'unlockcertsbutton',
-                    get_string('certificatelock_unlock', 'auth_saml2'));
+            $buttonarray[] = &$mform->createElement(
+                'submit',
+                'unlockcertsbutton',
+                get_string('certificatelock_unlock', 'auth_saml2')
+            );
         }
 
         $buttonarray[] = &$mform->createElement('cancel');

--- a/classes/form/regenerate.php
+++ b/classes/form/regenerate.php
@@ -37,7 +37,6 @@ require_once("$CFG->libdir/formslib.php");
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class regenerate extends moodleform {
-
     /**
      * Definition
      */
@@ -46,49 +45,91 @@ class regenerate extends moodleform {
 
         $mform->addElement('text', 'countryname', get_string('countryname', 'auth_saml2'), 'size=64');
         $mform->setType('countryname', PARAM_TEXT);
-        $mform->addRule('countryname', get_string('required', 'auth_saml2'),
-                'required', null, 'client');
+        $mform->addRule(
+            'countryname',
+            get_string('required', 'auth_saml2'),
+            'required',
+            null,
+            'client'
+        );
 
         $mform->addElement('text', 'stateorprovincename', get_string('stateorprovincename', 'auth_saml2'), 'size=64');
         $mform->setType('stateorprovincename', PARAM_TEXT);
-        $mform->addRule('stateorprovincename', get_string('required', 'auth_saml2'),
-                'required', null, 'client');
+        $mform->addRule(
+            'stateorprovincename',
+            get_string('required', 'auth_saml2'),
+            'required',
+            null,
+            'client'
+        );
 
         $mform->addElement('text', 'localityname', get_string('localityname', 'auth_saml2'), 'size=64');
         $mform->setType('localityname', PARAM_TEXT);
-        $mform->addRule('localityname', get_string('required', 'auth_saml2'),
-                'required', null, 'client');
+        $mform->addRule(
+            'localityname',
+            get_string('required', 'auth_saml2'),
+            'required',
+            null,
+            'client'
+        );
 
         $mform->addElement('text', 'organizationname', get_string('organizationname', 'auth_saml2'), 'size=64');
         $mform->setType('organizationname', PARAM_TEXT);
-        $mform->addRule('organizationname', get_string('required', 'auth_saml2'),
-                'required', null, 'client');
+        $mform->addRule(
+            'organizationname',
+            get_string('required', 'auth_saml2'),
+            'required',
+            null,
+            'client'
+        );
 
         $mform->addElement('text', 'organizationalunitname', get_string('organizationalunitname', 'auth_saml2'), 'size=64');
         $mform->setType('organizationalunitname', PARAM_TEXT);
-        $mform->addRule('organizationalunitname', get_string('required', 'auth_saml2'),
-                'required', null, 'client');
+        $mform->addRule(
+            'organizationalunitname',
+            get_string('required', 'auth_saml2'),
+            'required',
+            null,
+            'client'
+        );
 
         $mform->addElement('text', 'commonname', get_string('commonname', 'auth_saml2'), 'size=64');
         $mform->setType('commonname', PARAM_TEXT);
-        $mform->addRule('commonname', get_string('required', 'auth_saml2'),
-                'required', null, 'client');
+        $mform->addRule(
+            'commonname',
+            get_string('required', 'auth_saml2'),
+            'required',
+            null,
+            'client'
+        );
 
         $mform->addElement('text', 'email', get_string('email'), 'size=64');
         $mform->setType('email', PARAM_NOTAGS);
-        $mform->addRule('email', get_string('required', 'auth_saml2'),
-                'required', null, 'client');
+        $mform->addRule(
+            'email',
+            get_string('required', 'auth_saml2'),
+            'required',
+            null,
+            'client'
+        );
 
         $mform->addElement('text', 'expirydays', get_string('expirydays', 'auth_saml2'), 'size=5');
         $mform->setType('expirydays', PARAM_INT);
-        $mform->addRule('expirydays', get_string('requireint', 'auth_saml2'),
-                'numeric', null, 'client');
-        $mform->addRule('expirydays', get_string('requireint', 'auth_saml2'),
-                'required', null, 'client');
+        $mform->addRule(
+            'expirydays',
+            get_string('requireint', 'auth_saml2'),
+            'numeric',
+            null,
+            'client'
+        );
+        $mform->addRule(
+            'expirydays',
+            get_string('requireint', 'auth_saml2'),
+            'required',
+            null,
+            'client'
+        );
 
         $this->add_action_buttons(true, get_string('regenerate_submit', 'auth_saml2'));
-
     }
-
 }
-

--- a/classes/form/selectidp_buttons.php
+++ b/classes/form/selectidp_buttons.php
@@ -40,7 +40,6 @@ require_once("$CFG->libdir/formslib.php");
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class selectidp_buttons extends moodleform {
-
     /**
      * Definition
      */
@@ -53,13 +52,15 @@ class selectidp_buttons extends moodleform {
 
         $mform->addElement('hidden', 'wants', $wants);
         $mform->setType('wants', PARAM_URL);
-        $mform->addElement('checkbox', 'rememberidp' , '', get_string('rememberidp', 'auth_saml2'));
+        $mform->addElement('checkbox', 'rememberidp', '', get_string('rememberidp', 'auth_saml2'));
 
         foreach ($metadataentities as $idpentities) {
             if (isset($idpentities[$storedchoiceidp])) {
                 $storedchoiceidp = $idpentities[$storedchoiceidp];
-                $mform->addElement('html',
-                    $this->get_idpbutton($storedchoiceidp, $storedchoiceidp->name, $storedchoiceidp->logo, true));
+                $mform->addElement(
+                    'html',
+                    $this->get_idpbutton($storedchoiceidp, $storedchoiceidp->name, $storedchoiceidp->logo, true)
+                );
                 $mform->addElement('html', '<hr>');
                 unset($idpentities[$storedchoiceidp]);
             }
@@ -91,6 +92,4 @@ class selectidp_buttons extends moodleform {
 </div>
 EOD;
     }
-
 }
-

--- a/classes/form/selectidp_dropdown.php
+++ b/classes/form/selectidp_dropdown.php
@@ -40,7 +40,6 @@ require_once("$CFG->libdir/formslib.php");
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class selectidp_dropdown extends moodleform {
-
     /**
      * Definition
      */
@@ -56,10 +55,8 @@ class selectidp_dropdown extends moodleform {
         $mform->addElement('hidden', 'wants', $wants);
         $mform->setType('wants', PARAM_URL);
         $mform->addElement('select', 'idp', '', $idpentityids);
-        $mform->addElement('checkbox', 'rememberidp' , '', get_string('rememberidp', 'auth_saml2'));
+        $mform->addElement('checkbox', 'rememberidp', '', get_string('rememberidp', 'auth_saml2'));
 
         $mform->addElement('submit', 'login', $idpname, ['style' => 'margin-left:0px']);
     }
-
 }
-

--- a/classes/form/testidpselect.php
+++ b/classes/form/testidpselect.php
@@ -40,7 +40,6 @@ require_once("$CFG->libdir/formslib.php");
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class testidpselect extends moodleform {
-
     /**
      * Definition
      */
@@ -68,6 +67,4 @@ class testidpselect extends moodleform {
         $mform->addElement('select', 'idplogout', get_string('test_auth_button_logout', 'auth_saml2'), $selectvalues);
         $mform->addElement('submit', 'logout', get_string('test_auth_button_logout', 'auth_saml2'));
     }
-
 }
-

--- a/classes/group_rule.php
+++ b/classes/group_rule.php
@@ -29,7 +29,6 @@ namespace auth_saml2;
  * Class group_rule.
  */
 class group_rule {
-
     /**
      * Allow status.
      */
@@ -64,7 +63,7 @@ class group_rule {
      * @param string $config Rules config string.
      * @return \auth_saml2\group_rule[]
      */
-    public static function get_list(string  $config) {
+    public static function get_list(string $config) {
         $rules = [];
 
         $items = explode("\n", str_replace("\r\n", "\n", $config));

--- a/classes/idp_parser.php
+++ b/classes/idp_parser.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 namespace auth_saml2;
 
 /**
@@ -47,7 +48,6 @@ class idp_parser {
             $this->parse_xml($data);
         } else {
             $this->parse_urls($data);
-
         }
 
         return $this->idps;
@@ -114,13 +114,14 @@ class idp_parser {
                 $idpicon = $scheme . $parts[2];
 
                 $idpdata = new \auth_saml2\idp_data($idpname, $idpurl, $idpicon);
-
             } else if (count($parts) === 2) {
                 // Two elements could either be a IdPName + IdPURL, or IdPURL + IdPIcon.
 
                 // Detect if $parts[0] starts with a URL.
-                if (substr($parts[0], 0, 8) === 'https://' ||
-                    substr($parts[0], 0, 7) === 'http://') {
+                if (
+                    substr($parts[0], 0, 8) === 'https://' ||
+                    substr($parts[0], 0, 7) === 'http://'
+                ) {
                     $idpurl = $scheme . $parts[1];
                     $idpicon = $scheme . $parts[2];
 
@@ -132,7 +133,6 @@ class idp_parser {
 
                     $idpdata = new \auth_saml2\idp_data($idpname, $idpurl, null);
                 }
-
             } else if (count($parts) === 1) {
                 // One element is the previous default.
                 $idpurl = $scheme . $parts[0];

--- a/classes/local/hooks/output/before_http_headers.php
+++ b/classes/local/hooks/output/before_http_headers.php
@@ -24,7 +24,6 @@ namespace auth_saml2\local\hooks\output;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class before_http_headers {
-
     /**
      * Callback before HTTP headers are sent.
      *

--- a/classes/metadata_parser.php
+++ b/classes/metadata_parser.php
@@ -50,9 +50,8 @@ class metadata_parser {
      */
     public function parse($rawxml) {
         try {
-
             $xml = new \SimpleXMLElement($rawxml);
-            $xml->registerXPathNamespace('md',   'urn:oasis:names:tc:SAML:2.0:metadata');
+            $xml->registerXPathNamespace('md', 'urn:oasis:names:tc:SAML:2.0:metadata');
             $xml->registerXPathNamespace('mdui', 'urn:oasis:names:tc:SAML:metadata:ui');
 
             // Find all IDPSSODescriptor elements and then work back up to the entityID.

--- a/classes/metadata_writer.php
+++ b/classes/metadata_writer.php
@@ -67,7 +67,7 @@ class metadata_writer {
         if (!file_exists($this->certpath)) {
             make_writable_directory($this->certpath);
         }
-        $result = file_put_contents($this->certpath . $filename , $content);
+        $result = file_put_contents($this->certpath . $filename, $content);
         if ($result === false) {
             throw new \coding_exception('Could not write to file ' . $filename);
         }

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * Privacy Subsystem implementation for auth_saml2.
  *
@@ -31,7 +32,6 @@ namespace auth_saml2\privacy;
  */
 class provider implements
     \core_privacy\local\metadata\null_provider {
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.

--- a/classes/redis_store.php
+++ b/classes/redis_store.php
@@ -35,7 +35,6 @@ defined('MOODLE_INTERNAL') || die();
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class redis_store implements \SimpleSAML\Store\StoreInterface {
-
     /**
      * @var \Redis
      */

--- a/classes/ssl_algorithms.php
+++ b/classes/ssl_algorithms.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 namespace auth_saml2;
 
 defined('MOODLE_INTERNAL') || die();
@@ -55,7 +56,7 @@ abstract class ssl_algorithms {
      * @return string
      */
     public static function convert_signature_algorithm_to_digest_alg_format($signaturealgorithm) {
-        switch($signaturealgorithm) {
+        switch ($signaturealgorithm) {
             case 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256':
                 return 'SHA256';
             case 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha384':

--- a/classes/store.php
+++ b/classes/store.php
@@ -157,6 +157,4 @@ class store implements \SimpleSAML\Store\StoreInterface {
 
         $DB->execute($sql, $params);
     }
-
 }
-

--- a/classes/test/mock_settings.php
+++ b/classes/test/mock_settings.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 namespace auth_saml2\test;
 
 use admin_setting;

--- a/classes/testing/generator.php
+++ b/classes/testing/generator.php
@@ -30,7 +30,6 @@ use coding_exception;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class generator extends \core\testing\component_generator {
-
     use tests_generator;
 
     /**
@@ -38,5 +37,4 @@ final class generator extends \core\testing\component_generator {
      * @var int
      */
     protected $entitiescount = 0;
-
 }

--- a/classes/testing/tests_generator.php
+++ b/classes/testing/tests_generator.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 namespace auth_saml2\testing;
 
 defined('MOODLE_INTERNAL') || die();
@@ -26,7 +27,6 @@ defined('MOODLE_INTERNAL') || die();
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 trait tests_generator {
-
     /**
      * To be called from data reset code only,
      * do not use in tests.
@@ -66,7 +66,7 @@ trait tests_generator {
             $auth = get_auth_plugin('saml2');
             touch($auth->certcrt);
             touch($auth->certpem);
-            touch($auth->get_file(md5($idprecord['metadataurl']). ".idp.xml"));
+            touch($auth->get_file(md5($idprecord['metadataurl']) . ".idp.xml"));
         }
         return $DB->get_record('auth_saml2_idps', ['id' => $recordid]);
     }

--- a/classes/user_extractor.php
+++ b/classes/user_extractor.php
@@ -34,7 +34,6 @@ namespace auth_saml2;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class user_extractor {
-
     /**
      * Get extracted from DB user.
      *
@@ -59,7 +58,6 @@ class user_extractor {
         $params['mnethostid'] = $CFG->mnet_localhost_id;
 
         if (user_fields::is_custom_profile_field($fieldname)) {
-
             $fieldname = user_fields::get_field_short_name($fieldname);
 
             $joins = " LEFT JOIN {user_info_field} f ON f.shortname = :fieldname ";
@@ -67,7 +65,6 @@ class user_extractor {
 
             $fieldsql = " AND " . $DB->sql_equal('d.data', ':fieldvalue', !$insensitive, $accentsensitive);
             $params['fieldname'] = $fieldname;
-
         } else {
             // Check if requested field exists, required for Totara compatibility.
             $fields = array_merge(\core_user::AUTHSYNCFIELDS, ['id', 'username']);

--- a/classes/user_fields.php
+++ b/classes/user_fields.php
@@ -38,7 +38,6 @@ require_once($CFG->dirroot . '/user/profile/lib.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class user_fields {
-
     /**
      * A list of user matching fields from {user} table
      */
@@ -76,7 +75,7 @@ class user_fields {
         $customfields = profile_get_custom_fields(true);
 
         if (!empty($customfields)) {
-            $result = array_filter($customfields, function($customfield) {
+            $result = array_filter($customfields, function ($customfield) {
                 return in_array($customfield->datatype, self::SUPPORTED_TYPES_OF_PROFILE_FIELDS) &&
                     $customfield->forceunique == 1;
             });

--- a/config/config.php
+++ b/config/config.php
@@ -102,4 +102,3 @@ $config = [
 
 // Save this in a global for later.
 $saml2config = $config;
-

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -37,7 +37,6 @@ function xmldb_auth_saml2_upgrade($oldversion) {
     $dbman = $DB->get_manager();
 
     if ($oldversion < 2016031701) {
-
         // Define table auth_saml2_vkstore to be created.
         $table = new xmldb_table('auth_samltwo_kvstore');
 
@@ -206,7 +205,6 @@ function xmldb_auth_saml2_upgrade($oldversion) {
     }
 
     if ($oldversion < 2019022100) {
-
         // Define table auth_saml2_idps to be created.
         $tablename = 'auth_saml2_idps';
         $table = new xmldb_table($tablename);

--- a/debug.php
+++ b/debug.php
@@ -34,4 +34,3 @@ $PAGE->set_course($SITE);
 echo $OUTPUT->header();
 echo pretty_print($config);
 echo $OUTPUT->footer();
-

--- a/idp/slo.php
+++ b/idp/slo.php
@@ -24,7 +24,7 @@
 
 
 require_once(__DIR__ . '/../../../config.php');
-require_once($CFG->dirroot.'/auth/saml2/setup.php');
+require_once($CFG->dirroot . '/auth/saml2/setup.php');
 
 require_logout();
 

--- a/idp/sso.php
+++ b/idp/sso.php
@@ -24,7 +24,7 @@
 
 
 require_once(__DIR__ . '/../../../config.php');
-require_once($CFG->dirroot.'/auth/saml2/setup.php');
+require_once($CFG->dirroot . '/auth/saml2/setup.php');
 
 require_login(null, false);
 $relaystate = optional_param('RelayState', '', PARAM_RAW);

--- a/locallib.php
+++ b/locallib.php
@@ -497,16 +497,22 @@ function auth_saml2_admin_nav($title, $url) {
     $PAGE->set_url($url);
     $PAGE->set_course($SITE);
 
-    $PAGE->navbar->add(get_string('administrationsite'),
-            new moodle_url('/admin/search.php'));
+    $PAGE->navbar->add(
+        get_string('administrationsite'),
+        new moodle_url('/admin/search.php')
+    );
 
     $PAGE->navbar->add(get_string('plugins', 'admin'));
 
-    $PAGE->navbar->add(get_string('authentication', 'admin'),
-            new moodle_url('/admin/settings.php?section=manageauths'));
+    $PAGE->navbar->add(
+        get_string('authentication', 'admin'),
+        new moodle_url('/admin/settings.php?section=manageauths')
+    );
 
-    $PAGE->navbar->add(get_string('pluginname', 'auth_saml2'),
-            new moodle_url('/admin/settings.php', ['section' => 'authsettingsaml2']));
+    $PAGE->navbar->add(
+        get_string('pluginname', 'auth_saml2'),
+        new moodle_url('/admin/settings.php', ['section' => 'authsettingsaml2'])
+    );
 
     $PAGE->navbar->add($title, new moodle_url($url));
 

--- a/login.php
+++ b/login.php
@@ -41,4 +41,3 @@ if ($wantsurl !== '') {
 
 // Crap for hash anchor handling.
 $saml2auth->saml_login();
-

--- a/logout.php
+++ b/logout.php
@@ -35,4 +35,3 @@ require('setup.php');
 
 $auth = new SimpleSAML\Auth\Simple($saml2auth->spname);
 $auth->logout('/');
-

--- a/regenerate.php
+++ b/regenerate.php
@@ -60,8 +60,8 @@ echo "<p>Path: $path</p>";
 $data = openssl_x509_parse(file_get_contents($path));
 
 // Calculate date expirey interval.
-$date1 = date("Y-m-d\TH:i:s\Z", str_replace ('Z', '', $data['validFrom_time_t']));
-$date2 = date("Y-m-d\TH:i:s\Z", str_replace ('Z', '', $data['validTo_time_t']));
+$date1 = date("Y-m-d\TH:i:s\Z", str_replace('Z', '', $data['validFrom_time_t']));
+$date2 = date("Y-m-d\TH:i:s\Z", str_replace('Z', '', $data['validTo_time_t']));
 $datetime1 = new DateTime($date1);
 $datetime2 = new DateTime($date2);
 $interval = $datetime1->diff($datetime2);
@@ -93,4 +93,3 @@ echo html_writer::tag('p', get_string('regeneratepath', 'auth_saml2', $path));
 $mform->display();
 
 echo $OUTPUT->footer();
-

--- a/settings.php
+++ b/settings.php
@@ -33,7 +33,7 @@ defined('MOODLE_INTERNAL') || die;
 global $CFG;
 
 if ($ADMIN->fulltree) {
-    require_once($CFG->dirroot.'/auth/saml2/locallib.php');
+    require_once($CFG->dirroot . '/auth/saml2/locallib.php');
 
     $yesno = [
             new lang_string('no'),
@@ -41,8 +41,11 @@ if ($ADMIN->fulltree) {
     ];
 
     // Introductory explanation.
-    $settings->add(new admin_setting_heading('auth_saml2/pluginname', '',
-        new lang_string('auth_saml2description', 'auth_saml2')));
+    $settings->add(new admin_setting_heading(
+        'auth_saml2/pluginname',
+        '',
+        new lang_string('auth_saml2description', 'auth_saml2')
+    ));
 
     // IDP Metadata.
     $idpmetadata = new \auth_saml2\admin\setting_idpmetadata();
@@ -51,11 +54,12 @@ if ($ADMIN->fulltree) {
 
     // IDP name.
     $settings->add(new admin_setting_configtext(
-            'auth_saml2/idpname',
-            get_string('idpname', 'auth_saml2'),
-            get_string('idpname_help', 'auth_saml2'),
-            get_string('idpnamedefault', 'auth_saml2'),
-            PARAM_TEXT));
+        'auth_saml2/idpname',
+        get_string('idpname', 'auth_saml2'),
+        get_string('idpname_help', 'auth_saml2'),
+        get_string('idpnamedefault', 'auth_saml2'),
+        PARAM_TEXT
+    ));
 
     // Manage available IdPs.
     $settings->add(new setting_button(
@@ -64,41 +68,50 @@ if ($ADMIN->fulltree) {
         get_string('availableidps_help', 'auth_saml2'),
         get_string('availableidps', 'auth_saml2'),
         $CFG->wwwroot . '/auth/saml2/availableidps.php'
-        ));
+    ));
 
     // Display IDP Link.
     $settings->add(new admin_setting_configselect(
-            'auth_saml2/showidplink',
-            get_string('showidplink', 'auth_saml2'),
-            get_string('showidplink_help', 'auth_saml2'),
-            1, $yesno));
+        'auth_saml2/showidplink',
+        get_string('showidplink', 'auth_saml2'),
+        get_string('showidplink_help', 'auth_saml2'),
+        1,
+        $yesno
+    ));
 
     // IDP Metadata refresh.
     $settings->add(new admin_setting_configselect(
-            'auth_saml2/idpmetadatarefresh',
-            get_string('idpmetadatarefresh', 'auth_saml2'),
-            get_string('idpmetadatarefresh_help', 'auth_saml2'),
-            1, $yesno));
+        'auth_saml2/idpmetadatarefresh',
+        get_string('idpmetadatarefresh', 'auth_saml2'),
+        get_string('idpmetadatarefresh_help', 'auth_saml2'),
+        1,
+        $yesno
+    ));
 
     // Debugging.
     $settings->add(new admin_setting_configselect(
-            'auth_saml2/debug',
-            get_string('debug', 'auth_saml2'),
-            get_string('debug_help', 'auth_saml2', $CFG->wwwroot . '/auth/saml2/debug.php'),
-            0, $yesno));
+        'auth_saml2/debug',
+        get_string('debug', 'auth_saml2'),
+        get_string('debug_help', 'auth_saml2', $CFG->wwwroot . '/auth/saml2/debug.php'),
+        0,
+        $yesno
+    ));
 
     // Logging.
     $settings->add(new admin_setting_configselect(
-            'auth_saml2/logtofile',
-            get_string('logtofile', 'auth_saml2'),
-            get_string('logtofile_help', 'auth_saml2'),
-            0, $yesno));
+        'auth_saml2/logtofile',
+        get_string('logtofile', 'auth_saml2'),
+        get_string('logtofile_help', 'auth_saml2'),
+        0,
+        $yesno
+    ));
     $settings->add(new admin_setting_configtext(
-            'auth_saml2/logdir',
-            get_string('logdir', 'auth_saml2'),
-            get_string('logdir_help', 'auth_saml2'),
-            get_string('logdirdefault', 'auth_saml2'),
-            PARAM_TEXT));
+        'auth_saml2/logdir',
+        get_string('logdir', 'auth_saml2'),
+        get_string('logdir_help', 'auth_saml2'),
+        get_string('logdirdefault', 'auth_saml2'),
+        PARAM_TEXT
+    ));
 
     // See section 8.3 from http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf for more information.
     $nameidlist = [
@@ -116,55 +129,61 @@ if ($ADMIN->fulltree) {
         get_string('nameidpolicy', 'auth_saml2'),
         get_string('nameidpolicy_help', 'auth_saml2'),
         'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
-        array_combine($nameidlist, $nameidlist));
+        array_combine($nameidlist, $nameidlist)
+    );
     $nameidpolicy->set_updatedcallback('auth_saml2_update_sp_metadata');
     $settings->add($nameidpolicy);
 
     // Add NameID as attribute.
     $settings->add(new admin_setting_configselect(
-            'auth_saml2/nameidasattrib',
-            get_string('nameidasattrib', 'auth_saml2'),
-            get_string('nameidasattrib_help', 'auth_saml2'),
-            0, $yesno));
+        'auth_saml2/nameidasattrib',
+        get_string('nameidasattrib', 'auth_saml2'),
+        get_string('nameidasattrib_help', 'auth_saml2'),
+        0,
+        $yesno
+    ));
 
     // Lock certificate.
     $settings->add(new setting_button(
-            'auth_saml2/certificatelock',
-            get_string('certificatelock', 'auth_saml2'),
-            get_string('certificatelock_help', 'auth_saml2'),
-            get_string('certificatelock', 'auth_saml2'),
-            $CFG->wwwroot . '/auth/saml2/certificatelock.php'
-            ));
+        'auth_saml2/certificatelock',
+        get_string('certificatelock', 'auth_saml2'),
+        get_string('certificatelock_help', 'auth_saml2'),
+        get_string('certificatelock', 'auth_saml2'),
+        $CFG->wwwroot . '/auth/saml2/certificatelock.php'
+    ));
 
     // Regenerate certificate.
     $settings->add(new setting_button(
-            'auth_saml2/certificate',
-            get_string('certificate', 'auth_saml2'),
-            get_string('certificate_help', 'auth_saml2', $CFG->wwwroot . '/auth/saml2/cert.php'),
-            get_string('certificate', 'auth_saml2'),
-            $CFG->wwwroot . '/auth/saml2/regenerate.php'
-            ));
+        'auth_saml2/certificate',
+        get_string('certificate', 'auth_saml2'),
+        get_string('certificate_help', 'auth_saml2', $CFG->wwwroot . '/auth/saml2/cert.php'),
+        get_string('certificate', 'auth_saml2'),
+        $CFG->wwwroot . '/auth/saml2/regenerate.php'
+    ));
 
     $settings->add(new admin_setting_configpasswordunmask(
         'auth_saml2/privatekeypass',
         get_string('privatekeypass', 'auth_saml2'),
         get_string('privatekeypass_help', 'auth_saml2'),
         get_site_identifier(),
-        PARAM_TEXT));
+        PARAM_TEXT
+    ));
 
     // SP Metadata.
     $settings->add(new setting_textonly(
-           'auth_saml2/spmetadata',
-           get_string('spmetadata', 'auth_saml2'),
-           get_string('spmetadata_help', 'auth_saml2', $CFG->wwwroot . '/auth/saml2/sp/metadata.php')
-           ));
+        'auth_saml2/spmetadata',
+        get_string('spmetadata', 'auth_saml2'),
+        get_string('spmetadata_help', 'auth_saml2', $CFG->wwwroot . '/auth/saml2/sp/metadata.php')
+    ));
 
     // SP Metadata signature.
     $spmetadatasign = new admin_setting_configselect(
-            'auth_saml2/spmetadatasign',
-            get_string('spmetadatasign', 'auth_saml2'),
-            get_string('spmetadatasign_help', 'auth_saml2'),
-            0, $yesno);
+        'auth_saml2/spmetadatasign',
+        get_string('spmetadatasign', 'auth_saml2'),
+        get_string('spmetadatasign_help', 'auth_saml2'),
+        0,
+        $yesno
+    );
     $spmetadatasign->set_updatedcallback('auth_saml2_update_sp_metadata');
     $settings->add($spmetadatasign);
 
@@ -181,7 +200,8 @@ if ($ADMIN->fulltree) {
         'auth_saml2/wantassertionssigned',
         get_string('wantassertionssigned', 'auth_saml2'),
         get_string('wantassertionssigned_help', 'auth_saml2'),
-        0, $yesno
+        0,
+        $yesno
     );
     $wantassertionssigned->set_updatedcallback('auth_saml2_update_sp_metadata');
     $settings->add($wantassertionssigned);
@@ -206,14 +226,16 @@ if ($ADMIN->fulltree) {
         'auth_saml2/allowcreate',
         get_string('allowcreate', 'auth_saml2'),
         get_string('allowcreate_help', 'auth_saml2'),
-        0, $yesno
+        0,
+        $yesno
     ));
 
     $settings->add(new admin_setting_configtext(
         'auth_saml2/authncontext',
         get_string('authncontext', 'auth_saml2'),
         get_string('authncontext_help', 'auth_saml2'),
-        '', PARAM_TEXT
+        '',
+        PARAM_TEXT
     ));
 
     $settings->add(new admin_setting_configselect(
@@ -221,7 +243,8 @@ if ($ADMIN->fulltree) {
         get_string('signaturealgorithm', 'auth_saml2'),
         get_string('signaturealgorithm_help', 'auth_saml2'),
         ssl_algorithms::get_default_saml_signature_algorithm(),
-        ssl_algorithms::get_valid_saml_signature_algorithms()));
+        ssl_algorithms::get_valid_saml_signature_algorithms()
+    ));
 
     // Dual Login.
     $dualloginoptions = [
@@ -231,14 +254,16 @@ if ($ADMIN->fulltree) {
         saml2_settings::OPTION_DUAL_LOGIN_TEST    => get_string('test_idp_conn', 'auth_saml2'),
     ];
     $settings->add(new admin_setting_configselect(
-            'auth_saml2/duallogin',
-            get_string('duallogin', 'auth_saml2'),
-            get_string('duallogin_help', 'auth_saml2'),
-            saml2_settings::OPTION_DUAL_LOGIN_YES,
-            $dualloginoptions));
+        'auth_saml2/duallogin',
+        get_string('duallogin', 'auth_saml2'),
+        get_string('duallogin_help', 'auth_saml2'),
+        saml2_settings::OPTION_DUAL_LOGIN_YES,
+        $dualloginoptions
+    ));
 
     if (get_config('auth_saml2', 'duallogin') == saml2_settings::OPTION_DUAL_LOGIN_TEST) {
-        $settings->add(new admin_setting_configtext('auth_saml2/testendpoint',
+        $settings->add(new admin_setting_configtext(
+            'auth_saml2/testendpoint',
             get_string('test_endpoint', 'auth_saml2'),
             get_string('test_endpoint_desc', 'auth_saml2'),
             'https://example.com',
@@ -260,45 +285,56 @@ if ($ADMIN->fulltree) {
         saml2_settings::OPTION_AUTO_LOGIN_COOKIE => get_string('autologinbycookie', 'auth_saml2'),
     ];
     $settings->add(new admin_setting_configselect(
-            'auth_saml2/autologin',
-            get_string('autologin', 'auth_saml2'),
-            get_string('autologin_help', 'auth_saml2'),
-            saml2_settings::OPTION_AUTO_LOGIN_NO,
-            $autologinoptions));
+        'auth_saml2/autologin',
+        get_string('autologin', 'auth_saml2'),
+        get_string('autologin_help', 'auth_saml2'),
+        saml2_settings::OPTION_AUTO_LOGIN_NO,
+        $autologinoptions
+    ));
     $settings->add(new admin_setting_configtext(
-            'auth_saml2/autologincookie',
-            get_string('autologincookie', 'auth_saml2'),
-            get_string('autologincookie_help', 'auth_saml2'),
-            '', PARAM_TEXT));
+        'auth_saml2/autologincookie',
+        get_string('autologincookie', 'auth_saml2'),
+        get_string('autologincookie_help', 'auth_saml2'),
+        '',
+        PARAM_TEXT
+    ));
 
     // Allow any auth type.
     $settings->add(new admin_setting_configselect(
-            'auth_saml2/anyauth',
-            get_string('anyauth', 'auth_saml2'),
-            get_string('anyauth_help', 'auth_saml2'),
-            0, $yesno));
+        'auth_saml2/anyauth',
+        get_string('anyauth', 'auth_saml2'),
+        get_string('anyauth_help', 'auth_saml2'),
+        0,
+        $yesno
+    ));
 
     // Simplify attributes.
     $settings->add(new admin_setting_configselect(
-            'auth_saml2/attrsimple',
-            get_string('attrsimple', 'auth_saml2'),
-            get_string('attrsimple_help', 'auth_saml2'),
-            1, $yesno));
+        'auth_saml2/attrsimple',
+        get_string('attrsimple', 'auth_saml2'),
+        get_string('attrsimple_help', 'auth_saml2'),
+        1,
+        $yesno
+    ));
 
     // IDP to Moodle mapping.
     // IDP attribute.
     $settings->add(new admin_setting_configtext(
-            'auth_saml2/idpattr',
-            get_string('idpattr', 'auth_saml2'),
-            get_string('idpattr_help', 'auth_saml2'),
-            'uid', PARAM_TEXT));
+        'auth_saml2/idpattr',
+        get_string('idpattr', 'auth_saml2'),
+        get_string('idpattr_help', 'auth_saml2'),
+        'uid',
+        PARAM_TEXT
+    ));
 
     // Moodle Field.
     $settings->add(new admin_setting_configselect(
-            'auth_saml2/mdlattr',
-            get_string('mdlattr', 'auth_saml2'),
-            get_string('mdlattr_help', 'auth_saml2'),
-            'username', user_fields::get_supported_fields()));
+        'auth_saml2/mdlattr',
+        get_string('mdlattr', 'auth_saml2'),
+        get_string('mdlattr_help', 'auth_saml2'),
+        'username',
+        user_fields::get_supported_fields()
+    ));
 
     // Lowercase.
     $toloweroptions = [
@@ -308,11 +344,12 @@ if ($ADMIN->fulltree) {
         saml2_settings::OPTION_TOLOWER_CASE_AND_ACCENT_INSENSITIVE => get_string('tolower:caseandaccentinsensitive', 'auth_saml2'),
     ];
     $settings->add(new admin_setting_configselect(
-            'auth_saml2/tolower',
-            get_string('tolower', 'auth_saml2'),
-            get_string('tolower_help', 'auth_saml2'),
-            saml2_settings::OPTION_TOLOWER_EXACT,
-            $toloweroptions));
+        'auth_saml2/tolower',
+        get_string('tolower', 'auth_saml2'),
+        get_string('tolower_help', 'auth_saml2'),
+        saml2_settings::OPTION_TOLOWER_EXACT,
+        $toloweroptions
+    ));
 
     // Requested Attributes.
     $settings->add(new admin_setting_configtextarea(
@@ -322,14 +359,17 @@ if ($ADMIN->fulltree) {
 urn:mace:dir:attribute-def:eduPersonPrincipalName
 urn:mace:dir:attribute-def:mail *</pre>"]),
         '',
-        PARAM_TEXT));
+        PARAM_TEXT
+    ));
 
     // Autocreate Users.
     $settings->add(new admin_setting_configselect(
-            'auth_saml2/autocreate',
-            get_string('autocreate', 'auth_saml2'),
-            get_string('autocreate_help', 'auth_saml2'),
-            0, $yesno));
+        'auth_saml2/autocreate',
+        get_string('autocreate', 'auth_saml2'),
+        get_string('autocreate_help', 'auth_saml2'),
+        0,
+        $yesno
+    ));
 
     // Group access rules.
     $settings->add(new admin_setting_configtextarea(
@@ -337,15 +377,17 @@ urn:mace:dir:attribute-def:mail *</pre>"]),
         get_string('grouprules', 'auth_saml2'),
         get_string('grouprules_help', 'auth_saml2'),
         '',
-        PARAM_TEXT));
+        PARAM_TEXT
+    ));
 
     // Alternative Logout URL.
     $settings->add(new admin_setting_configtext(
-            'auth_saml2/alterlogout',
-            get_string('alterlogout', 'auth_saml2'),
-            get_string('alterlogout_help', 'auth_saml2'),
-            '',
-            PARAM_URL));
+        'auth_saml2/alterlogout',
+        get_string('alterlogout', 'auth_saml2'),
+        get_string('alterlogout_help', 'auth_saml2'),
+        '',
+        PARAM_URL
+    ));
 
     // Multi IdP display type.
     $multiidpdisplayoptions = [
@@ -357,7 +399,8 @@ urn:mace:dir:attribute-def:mail *</pre>"]),
         get_string('multiidpdisplay', 'auth_saml2'),
         get_string('multiidpdisplay_help', 'auth_saml2'),
         saml2_settings::OPTION_MULTI_IDP_DISPLAY_DROPDOWN,
-        $multiidpdisplayoptions));
+        $multiidpdisplayoptions
+    ));
 
     // Attempt Single Sign out.
     $settings->add(new admin_setting_configselect(
@@ -365,7 +408,8 @@ urn:mace:dir:attribute-def:mail *</pre>"]),
         get_string('attemptsignout', 'auth_saml2'),
         get_string('attemptsignout_help', 'auth_saml2'),
         1,
-        $yesno));
+        $yesno
+    ));
 
     // SAMLPHP tempdir.
     $settings->add(new admin_setting_configtext(
@@ -375,15 +419,16 @@ urn:mace:dir:attribute-def:mail *</pre>"]),
         '/tmp/simplesaml',
         PARAM_TEXT,
         50,
-        3));
+        3
+    ));
 
     // SAMLPHP version.
     $authplugin = get_auth_plugin('saml2');
     $settings->add(new setting_textonly(
-            'auth_saml2/sspversion',
-            get_string('sspversion', 'auth_saml2'),
-            $authplugin->get_ssp_version()
-            ));
+        'auth_saml2/sspversion',
+        get_string('sspversion', 'auth_saml2'),
+        $authplugin->get_ssp_version()
+    ));
 
 
     // Display locking / mapping of profile fields.
@@ -392,8 +437,11 @@ urn:mace:dir:attribute-def:mail *</pre>"]),
     $help .= get_string('auth_updateremote_expl', 'auth');
 
     // User block and redirect feature setting section.
-    $settings->add(new admin_setting_heading('auth_saml2/blockredirectheading', get_string('blockredirectheading', 'auth_saml2'),
-        new lang_string('auth_saml2blockredirectdescription', 'auth_saml2')));
+    $settings->add(new admin_setting_heading(
+        'auth_saml2/blockredirectheading',
+        get_string('blockredirectheading', 'auth_saml2'),
+        new lang_string('auth_saml2blockredirectdescription', 'auth_saml2')
+    ));
 
     // Flagged login response options.
     $flaggedloginresponseoptions = [
@@ -407,7 +455,8 @@ urn:mace:dir:attribute-def:mail *</pre>"]),
         get_string('flagresponsetype', 'auth_saml2'),
         get_string('flagresponsetype_help', 'auth_saml2'),
         saml2_settings::OPTION_FLAGGED_LOGIN_REDIRECT,
-        $flaggedloginresponseoptions));
+        $flaggedloginresponseoptions
+    ));
 
 
     // Set the http OR https fully qualified scheme domain name redirect destination for flagged accounts.
@@ -416,7 +465,8 @@ urn:mace:dir:attribute-def:mail *</pre>"]),
         get_string('flagredirecturl', 'auth_saml2'),
         get_string('flagredirecturl_help', 'auth_saml2'),
         '',
-        PARAM_URL));
+        PARAM_URL
+    ));
 
     // Set the displayed message for flagged accounts.
     $settings->add(new admin_setting_configtextarea(
@@ -426,42 +476,63 @@ urn:mace:dir:attribute-def:mail *</pre>"]),
         get_string('flagmessage_default', 'auth_saml2'),
         PARAM_TEXT,
         50,
-        3));
+        3
+    ));
 
     if (moodle_major_version() < '3.3') {
-        auth_saml2_display_auth_lock_options($settings, $authplugin->authtype, $authplugin->userfields, $help, true, true,
-            $authplugin->get_custom_user_profile_fields());
+        auth_saml2_display_auth_lock_options(
+            $settings,
+            $authplugin->authtype,
+            $authplugin->userfields,
+            $help,
+            true,
+            true,
+            $authplugin->get_custom_user_profile_fields()
+        );
     } else {
-        display_auth_lock_options($settings, $authplugin->authtype, $authplugin->userfields, $help, true, true,
-            $authplugin->get_custom_user_profile_fields());
+        display_auth_lock_options(
+            $settings,
+            $authplugin->authtype,
+            $authplugin->userfields,
+            $help,
+            true,
+            true,
+            $authplugin->get_custom_user_profile_fields()
+        );
     }
 
     // The field delimiter to use for multiple value fields from IdP.
     $settings->add(new admin_setting_configtext(
-            'auth_saml2/fielddelimiter',
-            get_string('fielddelimiter', 'auth_saml2'),
-            get_string('fielddelimiter_help', 'auth_saml2'),
-            ',',
-            PARAM_TEXT,
-            5));
+        'auth_saml2/fielddelimiter',
+        get_string('fielddelimiter', 'auth_saml2'),
+        get_string('fielddelimiter_help', 'auth_saml2'),
+        ',',
+        PARAM_TEXT,
+        5
+    ));
 
     // Moodle as an IDP feature setting section.
-    $settings->add(new admin_setting_heading('auth_saml2/moodleidpheading', get_string('moodleidpheading', 'auth_saml2'),
-        new lang_string('moodleidpdescription', 'auth_saml2')));
+    $settings->add(new admin_setting_heading(
+        'auth_saml2/moodleidpheading',
+        get_string('moodleidpheading', 'auth_saml2'),
+        new lang_string('moodleidpdescription', 'auth_saml2')
+    ));
 
     // Enable Moodle IDP.
     $settings->add(new admin_setting_configselect(
         'auth_saml2/moodleidpenabled',
         get_string('moodleidpenabled', 'auth_saml2'),
         get_string('moodleidpenabled_help', 'auth_saml2'),
-        0, $yesno));
+        0,
+        $yesno
+    ));
 
         // IDP Metadata.
     $settings->add(new setting_textonly(
         'auth_saml2/moodleidpmetadata',
         get_string('moodleidpmetadata', 'auth_saml2'),
         get_string('moodleidpmetadata_help', 'auth_saml2', $CFG->wwwroot . '/auth/saml2/idp/metadata.php')
-        ));
+    ));
 
     // List valid SPs.
     $settings->add(new admin_setting_configtextarea(
@@ -471,5 +542,6 @@ urn:mace:dir:attribute-def:mail *</pre>"]),
 https://www.someothermoodle.com/auth/saml2/sp/metadata.php
 </pre>"]),
         '',
-        PARAM_TEXT));
+        PARAM_TEXT
+    ));
 }

--- a/setup.php
+++ b/setup.php
@@ -52,8 +52,10 @@ if ($missingcertpem || $missingcertcrt) {
     $missingcertpem ? $errorstring .= "= Missing cert pem file! =\n" : null;
     $missingcertcrt ? $errorstring .= "= Missing cert crt file! = \n" : null;
     $errorstring .= "Now regenerating saml2 certificates...";
-    if (!(PHPUNIT_TEST || (defined('BEHAT_TEST') && BEHAT_TEST) ||
-            defined('BEHAT_SITE_RUNNING'))) {
+    if (
+        !(PHPUNIT_TEST || (defined('BEHAT_TEST') && BEHAT_TEST) ||
+            defined('BEHAT_SITE_RUNNING'))
+    ) {
         debugging($errorstring);
     }
     try {

--- a/setuplib.php
+++ b/setuplib.php
@@ -91,13 +91,12 @@ function create_certificates($saml2auth, $dn = false, $numberofdays = 3650) {
         return get_string('nullpubliccert', 'auth_saml2') . $errors;
     }
 
-    if ( !file_put_contents($saml2auth->certpem, $privatekey) ) {
+    if (!file_put_contents($saml2auth->certpem, $privatekey)) {
         return get_string('nullprivatecert', 'auth_saml2');
     }
-    if ( !file_put_contents($saml2auth->certcrt, $publickey) ) {
+    if (!file_put_contents($saml2auth->certcrt, $publickey)) {
         return get_string('nullpubliccert', 'auth_saml2');
     }
-
 }
 
 /**
@@ -134,8 +133,10 @@ function pretty_print($arr) {
             if (is_array($val)) {
                 $retstr .= '<tr><td>' . $key . '</td><td>' . pretty_print($val) . '</td></tr>';
             } else {
-                if (strpos($key, 'valid') !== false
-                    && is_int($val)) {
+                if (
+                    strpos($key, 'valid') !== false
+                    && is_int($val)
+                ) {
                     $val = userdate($val) . " ($val)";
                 }
                 $retstr .= '<tr><td>' . $key . '</td><td>' . ($val == '' ? '""' : $val) . '</td></tr>';
@@ -172,7 +173,6 @@ function get_dn_email() {
  * General saml exception
  */
 class saml2_exception extends moodle_exception {
-
     /**
      * Constructor
      *

--- a/sp/module.php
+++ b/sp/module.php
@@ -33,4 +33,4 @@ if (!empty($CFG->sslproxy)) {
     $_SERVER['SERVER_PORT'] = '443';
 }
 
-require($CFG->dirroot.'/auth/saml2/vendor/simplesamlphp/simplesamlphp/public/module.php');
+require($CFG->dirroot . '/auth/saml2/vendor/simplesamlphp/simplesamlphp/public/module.php');

--- a/sp/saml2-acs.php
+++ b/sp/saml2-acs.php
@@ -39,4 +39,3 @@ try {
 } catch (Exception $e) {
     throw new saml2_exception($e->getMessage(), $e->getTraceAsString());
 }
-

--- a/sp/saml2-logout.php
+++ b/sp/saml2-logout.php
@@ -67,4 +67,3 @@ try {
     // extlib/simplesamlphp/www/_include.php handles it.
     redirect(new moodle_url('/'));
 }
-

--- a/test.php
+++ b/test.php
@@ -106,4 +106,3 @@ if (!$auth->isAuthenticated() && $passive) {
     echo '</pre>';
     echo '<p>You are logged in: <a href="?logout=true&idplogout=' . md5($auth->getAuthData('saml:sp:IdP')) . '">Logout</a></p>';
 }
-

--- a/tests/auth_test.php
+++ b/tests/auth_test.php
@@ -32,6 +32,7 @@ final class auth_test extends \advanced_testcase {
      * Set up
      */
     public function setUp(): void {
+        parent::setUp();
         $this->resetAfterTest();
     }
 
@@ -104,7 +105,7 @@ final class auth_test extends \advanced_testcase {
 
         $auth->expects($this->once())
             ->method('error_page')
-            ->will($this->returnCallback(function($msg) {
+            ->will($this->returnCallback(function ($msg) {
                 throw new \coding_exception($msg);
             }));
         return $auth;
@@ -171,7 +172,7 @@ final class auth_test extends \advanced_testcase {
         $this->assertFalse($auth->is_configured());
 
         // Create xml.
-        touch($auth->get_file(md5($metadataurl). ".idp.xml"));
+        touch($auth->get_file(md5($metadataurl) . ".idp.xml"));
         $this->assertTrue($auth->is_configured());
     }
 
@@ -233,19 +234,41 @@ final class auth_test extends \advanced_testcase {
             // Check entity name.
             $this->assertEqualsCanonicalizing(['Login 1', $entity1->defaultname], array_column($auth->metadataentities, 'name'));
             // Encoded entityid present as an attribute as well as the key.
-            $this->assertEqualsCanonicalizing([md5($entity1->entityid), md5($entity3->entityid)],
-                array_column($auth->metadataentities, 'md5entityid'));
-            $this->assertEqualsCanonicalizing([md5($entity1->entityid), md5($entity3->entityid)],
-                array_keys($auth->metadataentities));
+            $this->assertEqualsCanonicalizing(
+                [md5($entity1->entityid), md5($entity3->entityid)],
+                array_column($auth->metadataentities, 'md5entityid')
+            );
+            $this->assertEqualsCanonicalizing(
+                [md5($entity1->entityid), md5($entity3->entityid)],
+                array_keys($auth->metadataentities)
+            );
         } else {
             // Check entity name.
-            $this->assertEquals(['Login 1', $entity1->defaultname],
-                array_column($auth->metadataentities, 'name'), '', 0, 10, true);
+            $this->assertEquals(
+                ['Login 1', $entity1->defaultname],
+                array_column($auth->metadataentities, 'name'),
+                '',
+                0,
+                10,
+                true
+            );
             // Encoded entityid present as an attribute as well as the key.
-            $this->assertEquals([md5($entity1->entityid), md5($entity3->entityid)],
-                array_column($auth->metadataentities, 'md5entityid'), '', 0, 10, true);
-            $this->assertEquals([md5($entity1->entityid), md5($entity3->entityid)],
-                array_keys($auth->metadataentities), '', 0, 10, true);
+            $this->assertEquals(
+                [md5($entity1->entityid), md5($entity3->entityid)],
+                array_column($auth->metadataentities, 'md5entityid'),
+                '',
+                0,
+                10,
+                true
+            );
+            $this->assertEquals(
+                [md5($entity1->entityid), md5($entity3->entityid)],
+                array_keys($auth->metadataentities),
+                '',
+                0,
+                10,
+                true
+            );
         }
 
         // Multiidp flag is true.
@@ -1039,10 +1062,10 @@ final class auth_test extends \advanced_testcase {
             '' => [[
                 ['uid' => 'test'], // User don't have groups attribute.
                 ['uid' => 'test', 'groups' => ['blocked']], // In blocked group.
-                ['uid' => 'test', 'groups' => ['allowed']],  // In allowed group.
+                ['uid' => 'test', 'groups' => ['allowed']], // In allowed group.
                 ['uid' => 'test', 'groups' => ['allowed', 'blocked']], // In both allowed first.
                 ['uid' => 'test', 'groups' => ['blocked', 'allowed']], // In both blocked first.
-                ['uid' => 'test', 'groups' => []],  // Groups exists, but empty.
+                ['uid' => 'test', 'groups' => []], // Groups exists, but empty.
             ]],
         ];
     }

--- a/tests/behat/behat_auth_saml2.php
+++ b/tests/behat/behat_auth_saml2.php
@@ -70,7 +70,7 @@ class behat_auth_saml2 extends behat_base {
      * @Given /^I go to the (login|self-test) page +\# auth_saml2$/
      */
     public function i_go_to_the_login_page_auth_saml($page) {
-        switch ($page){
+        switch ($page) {
             case 'login':
                 $page = '/login/index.php';
                 break;
@@ -277,8 +277,11 @@ EOF;
      */
     public function the_mock_saml_idp_allows_login_with_the_following_attributes($passive, TableNode $data) {
         // Check the correct page is current.
-        $this->find('xpath', '//h1[normalize-space(.)="Mock IdP login"]',
-                new ExpectationException('Not on the IdP login page.', $this->getSession()));
+        $this->find(
+            'xpath',
+            '//h1[normalize-space(.)="Mock IdP login"]',
+            new ExpectationException('Not on the IdP login page.', $this->getSession())
+        );
 
         // Find out if it's in passive mode.
         $pagepassive = $this->getSession()->getDriver()->find('//h2[normalize-space(.)="Passive mode"]');
@@ -307,11 +310,17 @@ EOF;
      */
     public function the_mock_saml_idp_does_not_allow_passive_login() {
         // Check the correct page is current.
-        $this->find('xpath', '//h1[normalize-space(.)="Mock IdP login"]',
-                new ExpectationException('Not on the IdP login page.', $this->getSession()));
+        $this->find(
+            'xpath',
+            '//h1[normalize-space(.)="Mock IdP login"]',
+            new ExpectationException('Not on the IdP login page.', $this->getSession())
+        );
 
-        $this->find('xpath', '//h2[normalize-space(.)="Passive mode"]',
-                new ExpectationException('Expected passive mode, but not passive.', $this->getSession()));
+        $this->find(
+            'xpath',
+            '//h2[normalize-space(.)="Passive mode"]',
+            new ExpectationException('Expected passive mode, but not passive.', $this->getSession())
+        );
 
         // Press the no-login button.
         $this->getSession()->getDriver()->click('//button[@id="nologin"]');
@@ -326,8 +335,11 @@ EOF;
      */
     public function the_mock_saml_idp_confirms_logout() {
         // Check the correct page is current.
-        $this->find('xpath', '//h1[normalize-space(.)="Mock IdP logout"]',
-                new ExpectationException('Not on the IdP logout page.', $this->getSession()));
+        $this->find(
+            'xpath',
+            '//h1[normalize-space(.)="Mock IdP logout"]',
+            new ExpectationException('Not on the IdP logout page.', $this->getSession())
+        );
 
         // Press the submit button.
         $this->getSession()->getDriver()->click('//button');

--- a/tests/fixtures/mockidp/slo.php
+++ b/tests/fixtures/mockidp/slo.php
@@ -96,11 +96,16 @@ echo html_writer::tag('pre', s($domxml->saveXML()));
 
 // Show a form.
 echo html_writer::start_tag('form', ['method' => 'post', 'action' => 'slo.php']);
-echo html_writer::empty_tag('input',
-        ['type' => 'hidden', 'name' => 'SAMLRequest', 'value' => $requestparam]);
+echo html_writer::empty_tag(
+    'input',
+    ['type' => 'hidden', 'name' => 'SAMLRequest', 'value' => $requestparam]
+);
 echo html_writer::start_div();
-echo html_writer::tag('div', html_writer::tag('button', 'Submit',
-        ['type' => 'submit', 'name' => 'login', 'value' => 1]));
+echo html_writer::tag('div', html_writer::tag(
+    'button',
+    'Submit',
+    ['type' => 'submit', 'name' => 'login', 'value' => 1]
+));
 
 echo html_writer::end_div();
 echo html_writer::end_tag('form');

--- a/tests/fixtures/mockidp/sso.php
+++ b/tests/fixtures/mockidp/sso.php
@@ -148,8 +148,10 @@ EOF;
     echo html_writer::tag('head', html_writer::tag('title', 'Behat SSO redirect back'));
     echo html_writer::start_tag('body');
     echo html_writer::start_tag('form', ['id' => 'frog', 'method' => 'post', 'action' => $destination]);
-    echo html_writer::empty_tag('input',
-            ['type' => 'hidden', 'name' => 'SAMLResponse', 'value' => base64_encode($outdoc->saveXML())]);
+    echo html_writer::empty_tag(
+        'input',
+        ['type' => 'hidden', 'name' => 'SAMLResponse', 'value' => base64_encode($outdoc->saveXML())]
+    );
     echo html_writer::end_tag('form');
     echo html_writer::tag('script', 'document.getElementById("frog").submit();');
     echo html_writer::end_tag('form');
@@ -210,21 +212,32 @@ echo html_writer::tag('pre', s($domxml->saveXML()));
 
 // Show a form.
 echo html_writer::start_tag('form', ['method' => 'post', 'action' => 'sso.php']);
-echo html_writer::empty_tag('input',
-        ['type' => 'hidden', 'name' => 'SAMLRequest', 'value' => $requestparam]);
+echo html_writer::empty_tag(
+    'input',
+    ['type' => 'hidden', 'name' => 'SAMLRequest', 'value' => $requestparam]
+);
 echo html_writer::start_div();
 echo html_writer::start_tag('label') . 'Attributes<br/>';
 $attributes = json_encode(['uid' => 'abc123', 'firstname' => 'Adam', 'surname' => 'Cliff',
         'email' => 'adam.cliff@example.com', 'lang' => 'en'], JSON_PRETTY_PRINT);
-echo html_writer::tag('textarea', $attributes,
-        ['id' => 'attributes', 'rows' => 10, 'cols' => 60, 'name' => 'attributes']);
+echo html_writer::tag(
+    'textarea',
+    $attributes,
+    ['id' => 'attributes', 'rows' => 10, 'cols' => 60, 'name' => 'attributes']
+);
 echo html_writer::end_tag('label');
 
-$buttons = html_writer::tag('button', 'Logged in',
-        ['type' => 'submit', 'id' => 'login', 'name' => 'login', 'value' => 1]);
+$buttons = html_writer::tag(
+    'button',
+    'Logged in',
+    ['type' => 'submit', 'id' => 'login', 'name' => 'login', 'value' => 1]
+);
 if ($passive) {
-    $buttons .= html_writer::tag('button', 'Not logged in',
-            ['type' => 'submit', 'id' => 'nologin', 'name' => 'nologin', 'value' => 1]);
+    $buttons .= html_writer::tag(
+        'button',
+        'Not logged in',
+        ['type' => 'submit', 'id' => 'nologin', 'name' => 'nologin', 'value' => 1]
+    );
 }
 echo html_writer::tag('div', $buttons);
 

--- a/tests/form_regenerate_test.php
+++ b/tests/form_regenerate_test.php
@@ -43,9 +43,9 @@ final class form_regenerate_test extends \advanced_testcase {
         $regenerateform = new regenerate();
         self::assertFalse($regenerateform->is_cancelled());
         $formdata = $regenerateform->get_data();
-        require_once($CFG->dirroot.'/auth/saml2/locallib.php');
-        require_once($CFG->dirroot.'/auth/saml2/auth.php');
-        require_once($CFG->dirroot.'/auth/saml2/setuplib.php');
+        require_once($CFG->dirroot . '/auth/saml2/locallib.php');
+        require_once($CFG->dirroot . '/auth/saml2/auth.php');
+        require_once($CFG->dirroot . '/auth/saml2/setuplib.php');
         auth_saml2_process_regenerate_form($formdata);
         self::assertSame('AU', $formdata->countryname);
         self::assertSame('moodle', $formdata->stateorprovincename);

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -23,7 +23,6 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class auth_saml2_generator extends component_generator_base {
-
     use auth_saml2\testing\tests_generator;
 
     /**
@@ -31,5 +30,4 @@ class auth_saml2_generator extends component_generator_base {
      * @var int
      */
     protected $entitiescount = 0;
-
 }

--- a/tests/generator_test.php
+++ b/tests/generator_test.php
@@ -32,6 +32,7 @@ final class generator_test extends \advanced_testcase {
      * Set up
      */
     public function setUp(): void {
+        parent::setUp();
         $this->resetAfterTest();
     }
 

--- a/tests/group_rule_test.php
+++ b/tests/group_rule_test.php
@@ -25,7 +25,6 @@ namespace auth_saml2;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class group_rule_test extends \advanced_testcase {
-
     /**
      * Test we can get list of rules from config string.
      */
@@ -43,5 +42,4 @@ final class group_rule_test extends \advanced_testcase {
         $this->assertEquals('blocked', $rules[1]->get_group());
         $this->assertEquals(false, $rules[1]->is_allowed());
     }
-
 }

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -68,12 +68,11 @@ final class locallib_test extends \advanced_testcase {
         $rawxml = auth_saml2_get_sp_metadata();
 
         $xml = new SimpleXMLElement($rawxml);
-        $xml->registerXPathNamespace('md',   'urn:oasis:names:tc:SAML:2.0:metadata');
+        $xml->registerXPathNamespace('md', 'urn:oasis:names:tc:SAML:2.0:metadata');
         $xml->registerXPathNamespace('mdui', 'urn:oasis:names:tc:SAML:metadata:ui');
 
         $contact = $xml->xpath('//md:EntityDescriptor/md:ContactPerson');
         $this->assertNotNull($contact);
-
     }
 
     /**

--- a/tests/metadata_fetcher_test.php
+++ b/tests/metadata_fetcher_test.php
@@ -25,7 +25,6 @@ namespace auth_saml2;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class metadata_fetcher_test extends \advanced_testcase {
-
     /** @var \Prophecy\Prophet */
     protected $prophet;
 
@@ -33,6 +32,7 @@ final class metadata_fetcher_test extends \advanced_testcase {
      * Set up
      */
     public function setUp(): void {
+        parent::setUp();
         if (class_exists('\\Prophecy\\Prophet')) {
             $this->prophet = new \Prophecy\Prophet();
         }
@@ -43,6 +43,7 @@ final class metadata_fetcher_test extends \advanced_testcase {
      */
     protected function tearDown(): void {
         $this->prophet = null; // Required for Totara 12+ support (see issue #578).
+        parent::tearDown();
     }
 
     public function test_fetch_metadata_404(): void {

--- a/tests/metadata_parser_test.php
+++ b/tests/metadata_parser_test.php
@@ -25,7 +25,6 @@ namespace auth_saml2;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class metadata_parser_test extends \basic_testcase {
-
     public function test_parse_metadata(): void {
         $xml = file_get_contents(__DIR__ . '/fixtures/metadata.xml');
 

--- a/tests/metadata_refresh_test.php
+++ b/tests/metadata_refresh_test.php
@@ -27,7 +27,6 @@ use auth_saml2\task\metadata_refresh;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class metadata_refresh_test extends \advanced_testcase {
-
     /** @var \Prophecy\Prophet */
     protected $prophet;
 
@@ -35,6 +34,7 @@ final class metadata_refresh_test extends \advanced_testcase {
      * Set up
      */
     public function setUp(): void {
+        parent::setUp();
         if (class_exists('\\Prophecy\\Prophet')) {
             $this->prophet = new \Prophecy\Prophet();
         }
@@ -46,6 +46,7 @@ final class metadata_refresh_test extends \advanced_testcase {
      */
     protected function tearDown(): void {
         $this->prophet = null;  // Required for Totara 12+ support (see issue #578).
+        parent::tearDown();
     }
 
     public function test_metadata_refresh_disabled(): void {
@@ -53,7 +54,7 @@ final class metadata_refresh_test extends \advanced_testcase {
         set_config('idpmetadata', 'http://somefakeidpurl.local', 'auth_saml2');
 
         $refreshtask = new metadata_refresh();
-        $this->expectOutputString('IdP metadata refresh is not configured. '.
+        $this->expectOutputString('IdP metadata refresh is not configured. ' .
             "Enable it in the auth settings or disable this scheduled task\n");
         self::assertFalse($refreshtask->execute());
     }

--- a/tests/metadata_writer_test.php
+++ b/tests/metadata_writer_test.php
@@ -25,7 +25,6 @@ namespace auth_saml2;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class metadata_writer_test extends \basic_testcase {
-
     public function test_write_default_path(): void {
         global $CFG;
 

--- a/tests/redis_store_test.php
+++ b/tests/redis_store_test.php
@@ -25,13 +25,13 @@ namespace auth_saml2;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class redis_store_test extends \advanced_testcase {
-
     /**
      * @var null|\Redis
      */
     protected $redis;
 
     public function setUp(): void {
+        parent::setUp();
         if (!$this->is_redis_available()) {
             $this->markTestSkipped('Redis was not available - skipping test');
         }
@@ -44,6 +44,7 @@ final class redis_store_test extends \advanced_testcase {
 
     public function tearDown(): void {
         unset($this->redis);
+        parent::tearDown();
     }
 
     public function test_set_with_expire(): void {

--- a/tests/setting_idpmetadata_test.php
+++ b/tests/setting_idpmetadata_test.php
@@ -149,7 +149,6 @@ final class setting_idpmetadata_test extends \advanced_testcase {
             // Maintains Support for Moodle 3.5 - remove when this branch does not support Moodle 3.5 anymore.
             self::assertContains('Invalid metadata', $error);
             self::assertContains('http://invalid.url.metadata.test', $error);
-
         }
     }
 

--- a/tests/ssl_algorithm_test.php
+++ b/tests/ssl_algorithm_test.php
@@ -26,18 +26,23 @@ namespace auth_saml2;
  */
 final class ssl_algorithm_test extends \basic_testcase {
     public function test_default_saml_signature_algorithm_is_valid_saml_signature_algorithm(): void {
-        $this->assertTrue(array_key_exists(ssl_algorithms::get_default_saml_signature_algorithm(),
-            ssl_algorithms::get_valid_saml_signature_algorithms()));
+        $this->assertTrue(array_key_exists(
+            ssl_algorithms::get_default_saml_signature_algorithm(),
+            ssl_algorithms::get_valid_saml_signature_algorithms()
+        ));
     }
 
     public function test_sha256_is_valid_saml_signature_algorithm(): void {
-        $this->assertTrue(array_key_exists('http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
-            ssl_algorithms::get_valid_saml_signature_algorithms()));
+        $this->assertTrue(array_key_exists(
+            'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+            ssl_algorithms::get_valid_saml_signature_algorithms()
+        ));
     }
 
     public function test_sha256_is_matching_digest_algorithm_for_default_saml_algorithm(): void {
         $this->assertEquals('SHA256', ssl_algorithms::convert_signature_algorithm_to_digest_alg_format(
-            ssl_algorithms::get_default_saml_signature_algorithm()));
+            ssl_algorithms::get_default_saml_signature_algorithm()
+        ));
     }
 
     public function test_sha256_is_matching_digest_algorithm_for_garbage_algorithm(): void {

--- a/tests/user_extractor_test.php
+++ b/tests/user_extractor_test.php
@@ -25,7 +25,6 @@ namespace auth_saml2;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class user_extractor_test extends \advanced_testcase {
-
     /**
      * A helper function to create a custom profile field.
      *
@@ -330,5 +329,4 @@ final class user_extractor_test extends \advanced_testcase {
         $actual = user_extractor::get_user('profile_field_field2', 'User 1 Field 2');
         $this->assertFalse($actual);
     }
-
 }

--- a/tests/user_fields_test.php
+++ b/tests/user_fields_test.php
@@ -25,7 +25,6 @@ namespace auth_saml2;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class user_fields_test extends \advanced_testcase {
-
     /**
      * A helper function to create a custom profile field.
      *


### PR DESCRIPTION
Closes #922 

Note, an additional commit is included that is an automatic code standards fixup, as it was causing the CI to fail.

See 5.0 PR as well: https://github.com/catalyst/moodle-auth_saml2/pull/924

I've recreated the original issue locally with keycloak saml2, and confirmed this fixes it.

Essentially, the connectivity test JS was being given a url with the params like `&amp saml=on` which it would then redirect to after successful connectivity test, but because of the space the `saml=on` was not detected by the saml auth handler, so it would think it still has to do a connectivity test, and this made it loop.