### PR TITLE
fix: adapt to SimpleSAMLphp configuration-getters and namespace refactors

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -39,7 +39,7 @@ function auth_saml2_get_sp_metadata($baseurl = '') {
 
     $sourceId = $saml2auth->spname;
 
-    $file = $saml2auth->get_file_sp_metadata_file($baseurl);
+    $file = $saml2auth->get_file_sp_metadata_file();
     if (file_exists($file)) {
         $xml = file_get_contents($file);
         return $xml;
@@ -146,40 +146,40 @@ function auth_saml2_get_sp_metadata($baseurl = '') {
         $metaArray20['NameIDFormat'] = $format;
     }
 
-    $name = $spconfig->getLocalizedString('name', NULL);
-    $attributes = $spconfig->getArray('attributes', array());
+    $name = $spconfig->getOptionalLocalizedString('name', NULL);
+    $attributes = $spconfig->getOptionalArray('attributes', array());
 
     if ($name !== NULL && !empty($attributes)) {
         $metaArray20['name'] = $name;
         $metaArray20['attributes'] = $attributes;
-        $metaArray20['attributes.required'] = $spconfig->getArray('attributes.required', array());
+        $metaArray20['attributes.required'] = $spconfig->getOptionalArray('attributes.required', array());
 
         if (empty($metaArray20['attributes.required'])) {
             unset($metaArray20['attributes.required']);
         }
 
-        $description = $spconfig->getArray('description', NULL);
+        $description = $spconfig->getOptionalArray('description', NULL);
         if ($description !== NULL) {
             $metaArray20['description'] = $description;
         }
 
-        $nameFormat = $spconfig->getString('attributes.NameFormat', NULL);
+        $nameFormat = $spconfig->getOptionalString('attributes.NameFormat', NULL);
         if ($nameFormat !== NULL) {
             $metaArray20['attributes.NameFormat'] = $nameFormat;
         }
     }
 
     // add organization info
-    $orgName = $spconfig->getLocalizedString('OrganizationName', NULL);
+    $orgName = $spconfig->getOptionalLocalizedString('OrganizationName', NULL);
     if ($orgName !== NULL) {
         $metaArray20['OrganizationName'] = $orgName;
 
-        $metaArray20['OrganizationDisplayName'] = $spconfig->getLocalizedString('OrganizationDisplayName', NULL);
+        $metaArray20['OrganizationDisplayName'] = $spconfig->getOptionalLocalizedString('OrganizationDisplayName', NULL);
         if ($metaArray20['OrganizationDisplayName'] === NULL) {
             $metaArray20['OrganizationDisplayName'] = $orgName;
         }
 
-        $metaArray20['OrganizationURL'] = $spconfig->getLocalizedString('OrganizationURL', NULL);
+        $metaArray20['OrganizationURL'] = $spconfig->getOptionalLocalizedString('OrganizationURL', NULL);
         if ($metaArray20['OrganizationURL'] === NULL) {
             throw new SimpleSAML_Error_Exception('If OrganizationName is set, OrganizationURL must also be set.');
         }
@@ -193,10 +193,10 @@ function auth_saml2_get_sp_metadata($baseurl = '') {
     }
 
     // add technical contact
-    $email = $config->getString('technicalcontact_email', 'na@example.org', FALSE);
+    $email = $config->getOptionalString('technicalcontact_email', FALSE);
     if ($email && $email !== 'na@example.org') {
         $techcontact['emailAddress'] = $email;
-        $techcontact['name'] = $config->getString('technicalcontact_name', NULL);
+        $techcontact['name'] = $config->getOptionalString('technicalcontact_name', NULL);
         $techcontact['contactType'] = 'technical';
         $metaArray20['contacts'][] = \SimpleSAML\Utils\Config\Metadata::getContact($techcontact);
     }

--- a/locallib.php
+++ b/locallib.php
@@ -23,6 +23,7 @@
  */
 
 use auth_saml2\event\cert_regenerated;
+use SimpleSAML\Error\Exception as SimpleSAML_Error_Exception;
 
 // @codingStandardsIgnoreStart
 /**

--- a/selectidp.php
+++ b/selectidp.php
@@ -24,6 +24,7 @@
  */
 
 use auth_saml2\admin\saml2_settings;
+use SimpleSAML\Error\Exception as SimpleSAML_Error_Exception;
 
 // @codingStandardsIgnoreStart
 require_once(__DIR__ . '/../../config.php');

--- a/sp/metadata.php
+++ b/sp/metadata.php
@@ -52,7 +52,7 @@ $xml = auth_saml2_get_sp_metadata($baseurl);
 
 if (array_key_exists('output', $_REQUEST) && $_REQUEST['output'] == 'xhtml') {
 
-	$t = new SimpleSAML_XHTML_Template($config, 'metadata.php', 'admin');
+	$t = new SimpleSAML\XHTML\Template($config, 'metadata.php');
 
 	$t->data['header'] = 'saml20-sp';
 	$t->data['metadata'] = htmlspecialchars($xml);

--- a/sp/metadata.php
+++ b/sp/metadata.php
@@ -26,6 +26,8 @@
  * @package    auth_saml2
  * @copyright  Brendan Heywood <brendan@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @var \SimpleSAML\Module\saml\Auth\Source\SP $source The Service Provider Source definition.
  */
 
 // @codingStandardsIgnoreStart

--- a/sp/metadata.php
+++ b/sp/metadata.php
@@ -60,7 +60,7 @@ if (array_key_exists('output', $_REQUEST) && $_REQUEST['output'] == 'xhtml') {
 	$t->data['metadata'] = htmlspecialchars($xml);
 	$t->data['metadataflat'] = '$metadata[' . var_export($entityId, TRUE) . '] = ' . var_export($metaArray20, TRUE) . ';';
 	$t->data['metaurl'] = $source->getMetadataURL();
-	$t->show();
+	$t->send();
 } else {
 	// header('Content-Type: application/samlmetadata+xml');
 	header('Content-Type: text/xml');


### PR DESCRIPTION
This PR is combining several adjustments that are long overdue dues to changes in the SimpleSamlPHP library.

Many of those issues already lead to fatal errors in production.

### Examples

- The configuration getters behaviour changed more than four years ago: https://github.com/simplesamlphp/simplesamlphp/pull/1605
- The `SimpleSAML_Error_Exception` was moved to `SimpleSAML\Error\Exception` such a long time ago, I have a hard time trying to find the commit, because the files also moved.