### PR TITLE
WR487120: T20 compatibility

### DIFF
--- a/classes/admin/setting_button.php
+++ b/classes/admin/setting_button.php
@@ -86,6 +86,6 @@ class setting_button extends heading {
             $element = $OUTPUT->render_from_template('auth_saml2/setting_configbutton', $context);
         }
 
-        return format_admin_setting($this, $this->visiblename, $element, $this->description);
+        return $this->render('', $element, null, $this->visiblename, '', '', $this->description);
     }
 }

--- a/classes/admin/setting_textonly.php
+++ b/classes/admin/setting_textonly.php
@@ -40,6 +40,6 @@ class setting_textonly extends heading {
      * @return string Returns an HTML string
      */
     public function output_html($data, $query = '') {
-        return format_admin_setting($this, $this->visiblename, '', $this->description);
+        return $this->render('', $this->visiblename, '', '', '', '', $this->description);
     }
 }


### PR DESCRIPTION
Fixes:
```
The function format_admin_setting() is deprecated please call the settings render() method instead.
line 419 of /lib/adminlib.php: call to debugging()
line 89 of /auth/saml2/classes/admin/setting_button.php: call to format_admin_setting()
line 182 of /lib/classes/setting/part/page.php: call to auth_saml2\admin\setting_button->output_html()
line 227 of /admin/settings.php: call to core\setting\part\page->output_html()

The function format_admin_setting() is deprecated please call the settings render() method instead.
line 419 of /lib/adminlib.php: call to debugging()
line 43 of /auth/saml2/classes/admin/setting_textonly.php: call to format_admin_setting()
line 182 of /lib/classes/setting/part/page.php: call to auth_saml2\admin\setting_textonly->output_html()
line 227 of /admin/settings.php: call to core\setting\part\page->output_html()
```