### PR TITLE
fix: improve wantsurl handling from loginpage list

### DIFF
--- a/login.php
+++ b/login.php
@@ -33,7 +33,8 @@ require_once(__DIR__ . '/../../config.php');
 // @codingStandardsIgnoreEnd
 require('setup.php');
 
-$wantsurl = optional_param('wantsurl', '', PARAM_LOCALURL); // Overrides $SESSION->wantsurl if given.
+// Get the wants if set. May be set as either wantsurl or wants from the button on the login page.
+$wantsurl = optional_param('wantsurl', '', PARAM_LOCALURL) ?: optional_param('wants', '', PARAM_LOCALURL);
 if ($wantsurl !== '') {
     // This is later used in core_login_get_return_url().
     $SESSION->wantsurl = (new moodle_url($wantsurl))->out(false);

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025040403;    // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2025040403;    // Match release exactly to version.
+$plugin->version   = 2025040404;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2025040404;    // Match release exactly to version.
 $plugin->requires  = 2024100700;    // Requires Moodle 4.5
 $plugin->component = 'auth_saml2';  // Full name of the plugin (used for diagnostics).
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
https://github.com/catalyst/moodle-auth_saml2/blob/MOODLE_500_STABLE/classes/auth.php#L291

This line sets up the button with 'wants' as a parameter. But then login.php never checks it. This patch just improves the case so that both wantsurl and wants are handled as parameters.