### PR TITLE
Feature: Add IDP Response Signing Capabilities

### DIFF
--- a/idp/sso.php
+++ b/idp/sso.php
@@ -148,12 +148,23 @@ $xpath = new DOMXPath($outdoc);
 $assertion = $xpath->query('//*[local-name()="Assertion"]')[0];
 $subject = $xpath->query('child::*[local-name()="Subject"]', $assertion)[0];
 
+//Find signing elements
+if ($saml2auth->config->moodleidpresponsesigning){
+    $response = $xpath->query('//*[local-name()="Response"]')[0];
+    $status = $xpath->query('child::*[local-name()="Status"]', $response)[0];
+}
+
 // Sign it using the fixture key/cert.
 $signer = new \SimpleSAML\XML\Signer(['id' => 'ID']);
 
 $signer->loadPrivateKey($saml2auth->certpem, $saml2auth->config->privatekeypass, true);
 $signer->loadCertificate($saml2auth->certcrt, true);
 $signer->sign($assertion, $assertion, $subject);
+
+//Sign response
+if ($saml2auth->config->moodleidpresponsesigning){
+    $signer->sign($response, $response, $status);
+}
 
 // Don't send as a referer or the login form might end up coming back here.
 header('Referrer-Policy: no-referrer');

--- a/lang/en/auth_saml2.php
+++ b/lang/en/auth_saml2.php
@@ -150,6 +150,8 @@ $string['moodleidpguest_error'] = 'Guest users cannot log in via SAML.';
 $string['moodleidpheading'] = 'Moodle IDP Settings';
 $string['moodleidpmetadata'] = 'IDP Metadata';
 $string['moodleidpmetadata_help'] = '<a href=\'{$a}\'>View Identity Provider Metadata</a> | <a href=\'{$a}?download=1\'>Download IDP Metadata</a>';
+$string['moodleidpresponsesigning'] = 'Sign IDP responses';
+$string['moodleidpresponsesigning_help'] = 'Whether responses sent by this IDP must be signed.';
 $string['moodleidpsplist'] = 'Valid Issuers';
 $string['moodleidpsplist_error'] = 'Unknown service attempting to authenticate: {$a}. Check config.';
 $string['moodleidpsplist_help'] = 'List of services allowed to use this moodle as an IDP identified by the <code>saml:Issuer</code> tag in the SAML request. One per line. {$a->example}';

--- a/settings.php
+++ b/settings.php
@@ -529,8 +529,8 @@ urn:mace:dir:attribute-def:mail *</pre>"]),
     // Enable Moodle IDP response signing.
     $settings->add(new admin_setting_configselect(
         'auth_saml2/moodleidpresponsesigning',
-        get_string('moodleresponsesigning','auth_saml2'),
-        get_string('moodleresponsesigning_help','auth_saml2'),
+        get_string('moodleidpresponsesigning','auth_saml2'),
+        get_string('moodleidpresponsesigning_help','auth_saml2'),
         0, $yesno));
 
         // IDP Metadata.

--- a/settings.php
+++ b/settings.php
@@ -526,6 +526,12 @@ urn:mace:dir:attribute-def:mail *</pre>"]),
         0,
         $yesno
     ));
+    // Enable Moodle IDP response signing.
+    $settings->add(new admin_setting_configselect(
+        'auth_saml2/moodleidpresponsesigning',
+        get_string('moodleresponsesigning','auth_saml2'),
+        get_string('moodleresponsesigning_help','auth_saml2'),
+        0, $yesno));
 
         // IDP Metadata.
     $settings->add(new setting_textonly(


### PR DESCRIPTION
Whilst this plugin has added IDP capabilities, it currently lacks a method to sign responses to SPs. This can be a problem when an SP expects responses to be signed, and is generally better for security overall. 

This pull request very simply adds a toggle to the plugin settings page asking if you want to sign your responses, along with using the pre-existing assertion signing framework to also sign the response if the option is selected.
